### PR TITLE
Fix: Change package name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@wdk/wallet",
+  "name": "@tetherto/wdk-wallet",
   "version": "1.0.0-beta.1",
   "description": "A simple package to manage BIP-32 wallets.",
   "keywords": ["wdk", "wallet", "bip-32"],


### PR DESCRIPTION
Change package name from `@wdk/wallet` to `@tetherto/wdk-wallet` ahead of open sourcing & publishing.