### PR TITLE
feat: publish workflow & documentation

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,49 @@
+name: publish
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      
+      - name: Set up Node 22.19.0
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22.19.0'
+          cache: 'npm'
+      
+      - name: Install dependencies
+        run: npm clean-install
+      
+      - name: Lint code with standard
+        run: npm run lint
+      
+      - name: Run tests
+        run: npm test
+
+  publish:
+    needs: test
+    runs-on: ubuntu-latest
+    environment: npm-publish
+    
+    steps:
+      - uses: actions/checkout@v3
+      
+      - name: Set up Node 22.19.0
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22.19.0'
+          cache: 'npm'
+          registry-url: 'https://registry.npmjs.org'
+      
+      - name: Install dependencies
+        run: npm clean-install
+
+      - name: Publish to npm
+        run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,39 @@
 # @wdk/wallet
+
+## What This Does
+
+Base classes for the wallet and protocol modules in the Wallet Development Kit (WDK)
+
+## Who Should Use This
+
+This module is for internal use only. If you want to build a wallet, use one of these instead:
+
+**Recommended:**
+- `@wdk/core` - Use this to work with multiple chains and features
+
+**Individual wallet modules:**
+- `@wdk/wallet-evm` - For Ethereum and EVM chains
+- `@wdk/wallet-evm-erc-4337` - For EVM chains with ERC-4337 support
+- `@wdk/wallet-btc` - For Bitcoin
+- `@wdk/wallet-ton` - For TON
+- `@wdk/wallet-ton-gasless` - For TON with gasless transactions
+- `@wdk/wallet-tron` - For TRON
+- `@wdk/wallet-tron-gasfree` - For TRON with gasless transactions
+- `@wdk/wallet-solana` - For Solana
+- `@wdk/wallet-spark` - For Spark
+
+
+## Key Parts
+
+- **WalletManager** - Base class for managing wallets
+- **WalletAccount** - Base class for wallet accounts
+- **WalletAccountReadOnly** - Base class for read-only accounts
+- **IWalletAccount** - Interface that all accounts must follow
+
+## Learn More
+
+For full docs, visit [docs.wallet.tether.io](https://docs.wallet.tether.io)
+
+## License
+
+This project is licensed under the Apache License 2.0 - see the [LICENSE](LICENSE) file for details.

--- a/README.md
+++ b/README.md
@@ -1,26 +1,26 @@
-# @wdk/wallet
+# @tetherto/wdk-wallet
 
 ## What This Does
 
-Base classes for the wallet and protocol modules in the Wallet Development Kit (WDK)
+Base classes for the wallet and protocol modules in the [Wallet Development Kit (WDK)](https://docs.wallet.tether.io).
 
 ## Who Should Use This
 
 This module is for internal use only. If you want to build a wallet, use one of these instead:
 
 **Recommended:**
-- `@wdk/core` - Use this to work with multiple chains and features
+- `@tetherto/wdk-core` - Use this to work with multiple chains and features
 
 **Individual wallet modules:**
-- `@wdk/wallet-evm` - For Ethereum and EVM chains
-- `@wdk/wallet-evm-erc-4337` - For EVM chains with ERC-4337 support
-- `@wdk/wallet-btc` - For Bitcoin
-- `@wdk/wallet-ton` - For TON
-- `@wdk/wallet-ton-gasless` - For TON with gasless transactions
-- `@wdk/wallet-tron` - For TRON
-- `@wdk/wallet-tron-gasfree` - For TRON with gasless transactions
-- `@wdk/wallet-solana` - For Solana
-- `@wdk/wallet-spark` - For Spark
+- `@tetherto/wdk-wallet-evm` - For Ethereum and EVM chains
+- `@tetherto/wdk-wallet-evm-erc-4337` - For EVM chains with ERC-4337 support
+- `@tetherto/wdk-wallet-btc` - For Bitcoin
+- `@tetherto/wdk-wallet-ton` - For TON
+- `@tetherto/wdk-wallet-ton-gasless` - For TON with gasless transactions
+- `@tetherto/wdk-wallet-tron` - For TRON
+- `@tetherto/wdk-wallet-tron-gasfree` - For TRON with gasless transactions
+- `@tetherto/wdk-wallet-solana` - For Solana
+- `@tetherto/wdk-wallet-spark` - For Spark
 
 
 ## Key Parts

--- a/package.json
+++ b/package.json
@@ -43,6 +43,10 @@
       "default": "./package.json"
     }
   },
+  "publishConfig": {
+    "access": "restricted",
+    "registry": "https://registry.npmjs.org/"
+  },
   "standard": {
     "ignore": [
       "bare.js",


### PR DESCRIPTION
Adds a `publish` GH workflow with the following characteristics:

- Trigger on release (when we tag a release on #main)
- Runs test and linting prior to publishing
- Uses the `npm-publish` environment
- Authentication: `setup-node` with registry-url + NODE_AUTH_TOKEN

Adds module documentation in the README