### PR TITLE
Feature - Sign tx

### DIFF
--- a/src/wallet-account.js
+++ b/src/wallet-account.js
@@ -72,7 +72,7 @@ export class IWalletAccount extends IWalletAccountReadOnly {
    * Signs a transaction
    *
    * @param {Transaction} tx - The transaction to sign.
-   * @returns {Promise<string>} The signed transaction as a hex string.
+   * @returns {Promise<unknown>} The signed transaction.
    */
   async signTransaction (tx) {
     throw new NotImplementedError('signTransaction(tx)')

--- a/src/wallet-account.js
+++ b/src/wallet-account.js
@@ -69,6 +69,16 @@ export class IWalletAccount extends IWalletAccountReadOnly {
   }
 
   /**
+   * Signs a transaction
+   *
+   * @param {Transaction} tx - The transaction to sign.
+   * @returns {Promise<string>} The signed transaction as a hex string.
+   */
+  async signTransaction (tx) {
+    throw new NotImplementedError('signTransaction(tx)')
+  }
+
+  /**
    * Verifies a message's signature.
    *
    * @param {string} message - The original message.

--- a/types/src/wallet-account.d.ts
+++ b/types/src/wallet-account.d.ts
@@ -26,6 +26,13 @@ export interface IWalletAccount extends IWalletAccountReadOnly {
      */
     sign(message: string): Promise<string>;
     /**
+     * Signs a transaction.
+     *
+     * @param {Transaction} tx - The transaction to sign.
+     * @returns {Promise<string>} The signed transaction as a hex string.
+     */
+    signTransaction(tx: Transaction): Promise<string>;
+    /**
      * Verifies a message's signature.
      *
      * @param {string} message - The original message.

--- a/types/src/wallet-account.d.ts
+++ b/types/src/wallet-account.d.ts
@@ -29,9 +29,9 @@ export interface IWalletAccount extends IWalletAccountReadOnly {
      * Signs a transaction.
      *
      * @param {Transaction} tx - The transaction to sign.
-     * @returns {Promise<string>} The signed transaction as a hex string.
+     * @returns {Promise<unknown>} The signed transaction.
      */
-    signTransaction(tx: Transaction): Promise<string>;
+    signTransaction(tx: Transaction): Promise<unknown>;
     /**
      * Verifies a message's signature.
      *


### PR DESCRIPTION
# Description
Add a new signTransaction method that signs a transaction and returns the raw signed transaction hex string.

## Motivation and Context
Currently, WDK only supports sendTransaction, which signs and broadcasts in one step. Some consumers want to sign a transaction locally and handle broadcasting themselves (e.g. to submit via a different relayer, queue the tx, or inspect it before sending). This new method supports that workflow while leaving sendTransaction unchanged.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
