### PR TITLE
Add WalletIndexerClient base class for interpreted multi-chain wallet data

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ This module is for internal use only. If you want to build a wallet, use one of 
 - **WalletAccount** - Base class for wallet accounts
 - **WalletAccountReadOnly** - Base class for read-only accounts
 - **IWalletAccount** - Interface that all accounts must follow
+- **WalletIndexerClient** - Base class for indexer clients (interpreted multi-chain portfolio, positions, transactions, NFTs, PnL)
 
 ## Learn More
 

--- a/index.js
+++ b/index.js
@@ -23,10 +23,26 @@
 
 /** @typedef {import('./src/wallet-account.js').KeyPair} KeyPair */
 
+/** @typedef {import('./src/indexer-client.js').PortfolioSummary} PortfolioSummary */
+/** @typedef {import('./src/indexer-client.js').PortfolioByChain} PortfolioByChain */
+/** @typedef {import('./src/indexer-client.js').TokenPosition} TokenPosition */
+/** @typedef {import('./src/indexer-client.js').PositionsResult} PositionsResult */
+/** @typedef {import('./src/indexer-client.js').PositionsOptions} PositionsOptions */
+/** @typedef {import('./src/indexer-client.js').InterpretedTransfer} InterpretedTransfer */
+/** @typedef {import('./src/indexer-client.js').InterpretedTransaction} InterpretedTransaction */
+/** @typedef {import('./src/indexer-client.js').TransactionsResult} TransactionsResult */
+/** @typedef {import('./src/indexer-client.js').TransactionsOptions} TransactionsOptions */
+/** @typedef {import('./src/indexer-client.js').NftPosition} NftPosition */
+/** @typedef {import('./src/indexer-client.js').NftsResult} NftsResult */
+/** @typedef {import('./src/indexer-client.js').NftsOptions} NftsOptions */
+/** @typedef {import('./src/indexer-client.js').PnlSummary} PnlSummary */
+
 export { default } from './src/wallet-manager.js'
 
 export { default as WalletAccountReadOnly, IWalletAccountReadOnly } from './src/wallet-account-read-only.js'
 
 export { IWalletAccount } from './src/wallet-account.js'
+
+export { default as WalletIndexerClient, IWalletIndexerClient } from './src/indexer-client.js'
 
 export { NotImplementedError } from './src/errors.js'

--- a/src/indexer-client.js
+++ b/src/indexer-client.js
@@ -1,0 +1,270 @@
+// Copyright 2024 Tether Operations Limited
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+'use strict'
+
+import { NotImplementedError } from './errors.js'
+
+/**
+ * @typedef {Object} PortfolioByChain
+ * @property {string} chain - The chain identifier (e.g. "ethereum", "arbitrum", "solana").
+ * @property {number} value - The total value held on this chain in the settlement currency.
+ */
+
+/**
+ * @typedef {Object} PortfolioSummary
+ * @property {string} address - The account's address.
+ * @property {string} currency - The settlement currency (e.g. "usd").
+ * @property {number} totalValue - The total portfolio value across all chains.
+ * @property {number} change24hAbsolute - Absolute portfolio value change over the last 24 hours.
+ * @property {number} change24hPercent - Percentage portfolio value change over the last 24 hours.
+ * @property {number} walletValue - Value held directly in the wallet (non-DeFi).
+ * @property {number} depositedValue - Value held in DeFi deposits.
+ * @property {number} stakedValue - Value held in staking positions.
+ * @property {number} borrowedValue - Value of outstanding borrow positions (negative contribution).
+ * @property {PortfolioByChain[]} byChain - Per-chain portfolio breakdown.
+ */
+
+/**
+ * @typedef {Object} TokenPosition
+ * @property {string} chain - The chain the position is held on.
+ * @property {string | null} contract - The token's contract address, or null for native tokens.
+ * @property {string} symbol - The token's symbol.
+ * @property {string} name - The token's name.
+ * @property {number} decimals - The token's decimals.
+ * @property {string} quantity - The held quantity as a decimal string (precision-safe).
+ * @property {number} priceUsd - The current price in the settlement currency.
+ * @property {number} valueUsd - The total value of the position in the settlement currency.
+ * @property {string} type - Position type (e.g. "wallet", "deposit", "staked", "borrowed", "reward").
+ * @property {string | null} protocol - The protocol the position belongs to, or null for plain wallet holdings.
+ */
+
+/**
+ * @typedef {Object} PositionsResult
+ * @property {TokenPosition[]} positions - The list of positions.
+ * @property {string | null} [nextCursor] - Opaque cursor for the next page, or null when no more pages.
+ */
+
+/**
+ * @typedef {Object} PositionsOptions
+ * @property {string[]} [chains] - Restrict to these chain identifiers.
+ * @property {string[]} [positionTypes] - Restrict to these position types.
+ * @property {string} [cursor] - Opaque cursor returned from a previous page.
+ * @property {number} [limit] - Maximum number of positions to return.
+ */
+
+/**
+ * @typedef {Object} InterpretedTransfer
+ * @property {'in' | 'out' | 'self'} direction - Direction of the transfer relative to the account.
+ * @property {string} symbol - The transferred token's symbol.
+ * @property {string} quantity - The transferred quantity as a decimal string (precision-safe).
+ * @property {number} valueUsd - The value of the transfer in the settlement currency.
+ * @property {string | null} contract - The token's contract address, or null for native tokens.
+ */
+
+/**
+ * @typedef {Object} InterpretedTransaction
+ * @property {string} hash - The on-chain transaction hash.
+ * @property {string} chain - The chain the transaction occurred on.
+ * @property {number} timestamp - The block timestamp in milliseconds since epoch.
+ * @property {string} type - Interpreted transaction type (e.g. "trade", "send", "receive", "approve").
+ * @property {string | null} protocol - The protocol the transaction interacted with, or null.
+ * @property {string} status - The transaction status (e.g. "confirmed", "failed").
+ * @property {InterpretedTransfer[]} transfers - The decoded token transfers in this transaction.
+ * @property {bigint | null} fee - The fee paid in native token base units, or null if unavailable.
+ */
+
+/**
+ * @typedef {Object} TransactionsResult
+ * @property {InterpretedTransaction[]} transactions - The list of interpreted transactions.
+ * @property {string | null} nextCursor - Opaque cursor for the next page, or null when no more pages.
+ */
+
+/**
+ * @typedef {Object} TransactionsOptions
+ * @property {string[]} [chains] - Restrict to these chain identifiers.
+ * @property {number} [limit] - Maximum number of transactions to return.
+ * @property {string} [cursor] - Opaque cursor returned from a previous page.
+ */
+
+/**
+ * @typedef {Object} NftPosition
+ * @property {string} chain - The chain the NFT is held on.
+ * @property {string} contract - The NFT contract address.
+ * @property {string} tokenId - The NFT's token ID.
+ * @property {string | null} name - The NFT's name, or null if unknown.
+ * @property {string | null} collection - The collection name, or null if unknown.
+ * @property {number | null} floorPriceUsd - The collection floor price in the settlement currency, or null.
+ * @property {number | null} lastSalePriceUsd - The NFT's last sale price in the settlement currency, or null.
+ * @property {string | null} imageUrl - A URL to the NFT's image, or null if unavailable.
+ */
+
+/**
+ * @typedef {Object} NftsResult
+ * @property {NftPosition[]} nfts - The list of NFT positions.
+ * @property {string | null} nextCursor - Opaque cursor for the next page, or null when no more pages.
+ */
+
+/**
+ * @typedef {Object} NftsOptions
+ * @property {string[]} [chains] - Restrict to these chain identifiers.
+ * @property {number} [limit] - Maximum number of NFTs to return.
+ * @property {string} [cursor] - Opaque cursor returned from a previous page.
+ */
+
+/**
+ * @typedef {Object} PnlSummary
+ * @property {string} address - The account's address.
+ * @property {string} currency - The settlement currency.
+ * @property {number} realizedPnlUsd - Realized profit and loss in the settlement currency.
+ * @property {number} unrealizedPnlUsd - Unrealized profit and loss in the settlement currency.
+ * @property {number} totalPnlUsd - Total (realized + unrealized) profit and loss.
+ * @property {number} netInvestedUsd - Net amount invested in the settlement currency.
+ * @property {number} totalFeesUsd - Total fees paid in the settlement currency.
+ */
+
+/** @interface */
+export class IWalletIndexerClient {
+  /**
+   * Returns a multi-chain portfolio summary for an account.
+   *
+   * @param {string} address - The account's address.
+   * @returns {Promise<PortfolioSummary>} The portfolio summary.
+   * @throws {Error} If the indexer client is not able to provide an implementation for the method.
+   */
+  async getPortfolio (address) {
+    throw new NotImplementedError('getPortfolio(address)')
+  }
+
+  /**
+   * Returns the decoded token and DeFi positions held by an account.
+   *
+   * @param {string} address - The account's address.
+   * @param {PositionsOptions} [options] - Optional filters and pagination cursor.
+   * @returns {Promise<PositionsResult>} The list of positions.
+   * @throws {Error} If the indexer client is not able to provide an implementation for the method.
+   */
+  async getPositions (address, options) {
+    throw new NotImplementedError('getPositions(address, options)')
+  }
+
+  /**
+   * Returns interpreted (decoded) transactions for an account.
+   *
+   * @param {string} address - The account's address.
+   * @param {TransactionsOptions} [options] - Optional filters and pagination cursor.
+   * @returns {Promise<TransactionsResult>} The list of interpreted transactions.
+   * @throws {Error} If the indexer client is not able to provide an implementation for the method.
+   */
+  async getTransactions (address, options) {
+    throw new NotImplementedError('getTransactions(address, options)')
+  }
+
+  /**
+   * Returns the NFTs held by an account.
+   *
+   * @param {string} address - The account's address.
+   * @param {NftsOptions} [options] - Optional filters and pagination cursor.
+   * @returns {Promise<NftsResult>} The list of NFT positions.
+   * @throws {Error} If the indexer client is not able to provide an implementation for the method.
+   */
+  async getNfts (address, options) {
+    throw new NotImplementedError('getNfts(address, options)')
+  }
+
+  /**
+   * Returns realized and unrealized profit and loss for an account.
+   *
+   * @param {string} address - The account's address.
+   * @returns {Promise<PnlSummary>} The PnL summary.
+   * @throws {Error} If the indexer client is not able to provide an implementation for the method.
+   */
+  async getPnl (address) {
+    throw new NotImplementedError('getPnl(address)')
+  }
+}
+
+/**
+ * Base class for indexer clients that provide interpreted multi-chain wallet
+ * data (portfolio, positions, transactions, NFTs, PnL) for any wallet account.
+ *
+ * Concrete implementations live in their own packages, e.g.
+ * `@zerion/wdk-indexer-zerion`, mirroring the `PricingClient` pattern.
+ *
+ * @abstract
+ * @implements {IWalletIndexerClient}
+ */
+export default class WalletIndexerClient {
+  /**
+   * Returns a multi-chain portfolio summary for an account.
+   *
+   * @abstract
+   * @param {string} address - The account's address.
+   * @returns {Promise<PortfolioSummary>} The portfolio summary.
+   * @throws {Error} If the indexer client is not able to provide an implementation for the method.
+   */
+  async getPortfolio (address) {
+    throw new NotImplementedError('getPortfolio(address)')
+  }
+
+  /**
+   * Returns the decoded token and DeFi positions held by an account.
+   *
+   * @abstract
+   * @param {string} address - The account's address.
+   * @param {PositionsOptions} [options] - Optional filters and pagination cursor.
+   * @returns {Promise<PositionsResult>} The list of positions.
+   * @throws {Error} If the indexer client is not able to provide an implementation for the method.
+   */
+  async getPositions (address, options) {
+    throw new NotImplementedError('getPositions(address, options)')
+  }
+
+  /**
+   * Returns interpreted (decoded) transactions for an account.
+   *
+   * @abstract
+   * @param {string} address - The account's address.
+   * @param {TransactionsOptions} [options] - Optional filters and pagination cursor.
+   * @returns {Promise<TransactionsResult>} The list of interpreted transactions.
+   * @throws {Error} If the indexer client is not able to provide an implementation for the method.
+   */
+  async getTransactions (address, options) {
+    throw new NotImplementedError('getTransactions(address, options)')
+  }
+
+  /**
+   * Returns the NFTs held by an account.
+   *
+   * @abstract
+   * @param {string} address - The account's address.
+   * @param {NftsOptions} [options] - Optional filters and pagination cursor.
+   * @returns {Promise<NftsResult>} The list of NFT positions.
+   * @throws {Error} If the indexer client is not able to provide an implementation for the method.
+   */
+  async getNfts (address, options) {
+    throw new NotImplementedError('getNfts(address, options)')
+  }
+
+  /**
+   * Returns realized and unrealized profit and loss for an account.
+   *
+   * @abstract
+   * @param {string} address - The account's address.
+   * @returns {Promise<PnlSummary>} The PnL summary.
+   * @throws {Error} If the indexer client is not able to provide an implementation for the method.
+   */
+  async getPnl (address) {
+    throw new NotImplementedError('getPnl(address)')
+  }
+}

--- a/tests/indexer-client.test.js
+++ b/tests/indexer-client.test.js
@@ -1,0 +1,74 @@
+import { describe, expect, test } from '@jest/globals'
+
+import { WalletIndexerClient } from '../index.js'
+
+const ADDRESS = '0xa460AEbce0d3A4BecAd8ccf9D6D4861296c503Bd'
+
+class DummyWalletIndexerClient extends WalletIndexerClient {
+  async getPortfolio (address) {
+    return {
+      address,
+      currency: 'usd',
+      totalValue: 0,
+      change24hAbsolute: 0,
+      change24hPercent: 0,
+      walletValue: 0,
+      depositedValue: 0,
+      stakedValue: 0,
+      borrowedValue: 0,
+      byChain: []
+    }
+  }
+}
+
+class EmptyWalletIndexerClient extends WalletIndexerClient {}
+
+describe('WalletIndexerClient', () => {
+  describe('getPortfolio', () => {
+    test('should return the portfolio summary from the implementation', async () => {
+      const client = new DummyWalletIndexerClient()
+      const portfolio = await client.getPortfolio(ADDRESS)
+      expect(portfolio.address).toBe(ADDRESS)
+      expect(portfolio.currency).toBe('usd')
+      expect(portfolio.byChain).toEqual([])
+    })
+
+    test('should throw NotImplementedError if not implemented', async () => {
+      const client = new EmptyWalletIndexerClient()
+      await expect(client.getPortfolio(ADDRESS))
+        .rejects.toThrow("Method 'getPortfolio(address)' must be implemented.")
+    })
+  })
+
+  describe('getPositions', () => {
+    test('should throw NotImplementedError if not implemented', async () => {
+      const client = new EmptyWalletIndexerClient()
+      await expect(client.getPositions(ADDRESS))
+        .rejects.toThrow("Method 'getPositions(address, options)' must be implemented.")
+    })
+  })
+
+  describe('getTransactions', () => {
+    test('should throw NotImplementedError if not implemented', async () => {
+      const client = new EmptyWalletIndexerClient()
+      await expect(client.getTransactions(ADDRESS))
+        .rejects.toThrow("Method 'getTransactions(address, options)' must be implemented.")
+    })
+  })
+
+  describe('getNfts', () => {
+    test('should throw NotImplementedError if not implemented', async () => {
+      const client = new EmptyWalletIndexerClient()
+      await expect(client.getNfts(ADDRESS))
+        .rejects.toThrow("Method 'getNfts(address, options)' must be implemented.")
+    })
+  })
+
+  describe('getPnl', () => {
+    test('should throw NotImplementedError if not implemented', async () => {
+      const client = new EmptyWalletIndexerClient()
+      await expect(client.getPnl(ADDRESS))
+        .rejects.toThrow("Method 'getPnl(address)' must be implemented.")
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Adds `WalletIndexerClient` (and the `IWalletIndexerClient` interface) as a new abstract base in `@tetherto/wdk-wallet`, sibling to `WalletAccountReadOnly` and `WalletAccount`. It defines a vendor-agnostic contract for **interpreted multi-chain wallet data** — portfolio rollups, decoded DeFi positions, interpreted transactions, NFTs, and PnL — that any indexer vendor can implement.

Working concrete implementation already exists at **https://github.com/abishekdharshan/wdk-indexer-zerion** (Apache-2.0, Zerion-backed). It satisfies this interface end-to-end and is what motivated extracting the abstract base.

## Why

WDK is excellent at the wallet primitives — derive, sign, send, estimate — but stays thin on reads. Today every chain-specific wallet calls RPC for a single native balance or single ERC-20 balance, and there is no surface for:

- Cross-chain portfolio rollups (one address, one number, every chain)
- Decoded DeFi positions (e.g. "USDC deposited in Aave V3", not raw contract reads)
- Interpreted transactions (e.g. "Swap 1.2 ETH for 4,200 USDC on Uniswap V3", not raw calldata)
- NFTs with floor + last-sale prices
- Realized + unrealized PnL

App developers consuming WDK end up wiring this themselves, per chain, per vendor. `PricingClient` solved the same problem for prices; this PR solves it for indexer data.

## Design

Mirrors the existing two-class pattern used by `WalletAccountReadOnly`:

- `IWalletIndexerClient` — `@interface` with all method signatures throwing `NotImplementedError`
- `WalletIndexerClient` — `@abstract` class `@implements {IWalletIndexerClient}`, with the same default-throw behaviour

Methods (all return Promises, all surface JSDoc typedefs):

```js
getPortfolio(address)              // PortfolioSummary — total + by-chain + 24h change
getPositions(address, options)     // PositionsResult  — { positions, nextCursor? }
getTransactions(address, options)  // TransactionsResult — { transactions, nextCursor }
getNfts(address, options)          // NftsResult — { nfts, nextCursor }
getPnl(address)                    // PnlSummary
```

Quantities returned as **decimal strings** (precision-safe), USD values as numbers, fees as `bigint | null` matching WDK conventions. Chain identifiers are vendor-agnostic strings (`"ethereum"`, `"arbitrum"`, `"solana"`, …) so multiple implementations can interop.

## Files changed

- `src/indexer-client.js` — new, ~260 LOC, JSDoc-typed, matches `wallet-account-read-only.js` style exactly (`'use strict'`, `NotImplementedError` from `./errors.js`, single quotes, no semicolons, space before parens, copyright header)
- `index.js` — exports `WalletIndexerClient` + `IWalletIndexerClient` + re-exports the typedefs
- `tests/indexer-client.test.js` — jest, mirrors `wallet-account-read-only.test.js` structure (Dummy + Empty subclasses, `rejects.toThrow`)
- `README.md` — adds `WalletIndexerClient` to **Key Parts**

No changes to existing code paths. Pure addition.

## Why it lives here vs. its own repo

The cleanest match for Tether's existing layout would be a separate `tetherto/wdk-indexer-provider` repo, mirroring how `PricingClient` lives in [`tetherto/wdk-pricing-provider`](https://github.com/tetherto/wdk-pricing-provider) with `BitfinexPricingClient` in a sibling repo. I can't create a new repo on the `tetherto` org from outside, so this PR puts the abstract on the closest existing host. **Happy to factor it out into a standalone `wdk-indexer-provider` package on Tether's signal** — the abstract has zero runtime deps and lifts cleanly.

## Concrete implementation

[`@zerion/wdk-indexer-zerion`](https://github.com/abishekdharshan/wdk-indexer-zerion) (Apache-2.0):

- Backed by [Zerion's API](https://developers.zerion.io) — already powering Coinbase Wallet, Uniswap, Rainbow, Revolut, Kraken, Safe in production
- Covers EVM mainnets + major L2s + Solana; BTC/Tron/TON/Spark intentionally out of scope (future indexer clients can fill those gaps)
- Working `examples/portfolio-demo.js` derives an account via `@tetherto/wdk-wallet-evm` and prints portfolio, positions, transactions, and PnL in <100 LOC

## Status

Draft — happy to iterate on naming, method shape, typedef granularity, or repo placement before merge. No rush from this side.

cc @tetherto maintainers — flagging Jonathan / WDK leads as appropriate.
