### PR TITLE
Add transactionMaxFee

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tetherto/wdk-wallet",
-  "version": "1.0.0-beta.8",
+  "version": "1.0.0-beta.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tetherto/wdk-wallet",
-      "version": "1.0.0-beta.8",
+      "version": "1.0.0-beta.9",
       "license": "Apache-2.0",
       "dependencies": {
         "bare-node-runtime": "^1.1.4",
@@ -50,6 +50,7 @@
       "integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.3",
@@ -1225,6 +1226,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1656,6 +1658,7 @@
       "resolved": "https://registry.npmjs.org/bare-abort-controller/-/bare-abort-controller-1.0.0.tgz",
       "integrity": "sha512-RSUPsS16TC0EfqfjZUlQwLAtFCUUl7NA0CYaE4/Sl9ExFx3q0WIogBHmW5Zn16NRZUHDJqEffmtnvIyw6LFUjA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "bare-events": "^2.7.0"
       }
@@ -1715,6 +1718,7 @@
       "resolved": "https://registry.npmjs.org/bare-buffer/-/bare-buffer-3.4.0.tgz",
       "integrity": "sha512-KN2Clfo9Tm0+1bRJxTNqX5Z1skLX8XbvJBGePkCqeGJ1fjV/2VXFc8Eb7NXBU7TM+jlUo7e7sGG5posv+EnU6A==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "bare": ">=1.20.0"
       }
@@ -2424,6 +2428,7 @@
       "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.2.2.tgz",
       "integrity": "sha512-g+ueNGKkrjMazDG3elZO1pNs3HY5+mMmOet1jtKyhOaCnkLzitxf26z7hoAEkDNgdNmnc1KIlt/dw6Po6xZMpA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "bare-path": "^3.0.0"
       }
@@ -2567,6 +2572,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.9",
         "caniuse-lite": "^1.0.30001746",
@@ -3316,6 +3322,7 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -3523,6 +3530,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -3580,6 +3588,7 @@
       "integrity": "sha512-jDex9s7D/Qial8AGVIHq4W7NswpUD5DPDL2RH8Lzd9EloWUuvUkHfv4FRLMipH5q2UtyurorBkPeNi1wVWNh3Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "builtins": "^5.0.1",
         "eslint-plugin-es": "^4.1.0",
@@ -3619,6 +3628,7 @@
       "integrity": "sha512-57Zzfw8G6+Gq7axm2Pdo3gW/Rx3h9Yywgn61uE/3elTCOePEHVrn2i5CdfBwA1BLK0Q0WqctICIUSqXZW/VprQ==",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
@@ -3635,6 +3645,7 @@
       "integrity": "sha512-Qteup0SqU15kdocexFNAJMvCJEfa2xUKNV4CC1xsVMrIIqEy3SQ/rqyxCWNzfrd3/ldy6HMlD2e0JDVpDg2qIA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "array-includes": "^3.1.8",
         "array.prototype.findlast": "^1.2.5",

--- a/src/wallet-manager.js
+++ b/src/wallet-manager.js
@@ -22,6 +22,7 @@ import { NotImplementedError } from './errors.js'
 /**
  * @typedef {Object} WalletConfig
  * @property {number | bigint} [transferMaxFee] - The maximum fee amount for transfer operations.
+ * @property {number | bigint} [transactionMaxFee] - The maximum fee amount for sendTransaction and signTransaction operations.
  */
 
 /**

--- a/tests/wallet-manager.test.js
+++ b/tests/wallet-manager.test.js
@@ -50,6 +50,13 @@ describe('WalletManager', () => {
       expect(() => { new DummyWalletManager(INVALID_SEED_PHRASE) })
         .toThrow('The seed phrase is invalid.')
     })
+
+    test('should store both transferMaxFee and transactionMaxFee in config', () => {
+      const wallet = new DummyWalletManager(SEED_PHRASE, { transferMaxFee: 100, transactionMaxFee: 500 })
+
+      expect(wallet._config.transferMaxFee).toBe(100)
+      expect(wallet._config.transactionMaxFee).toBe(500)
+    })
   })
 
   describe('static getRandomSeedPhrase', () => {

--- a/types/src/wallet-manager.d.ts
+++ b/types/src/wallet-manager.d.ts
@@ -79,6 +79,10 @@ export type WalletConfig = {
      * - The maximum fee amount for transfer operations.
      */
     transferMaxFee?: number | bigint;
+    /**
+     * - The maximum fee amount for sendTransaction and signTransaction operations.
+     */
+    transactionMaxFee?: number | bigint;
 };
 export type FeeRates = {
     /**


### PR DESCRIPTION
# Description

Adding a `transactionMaxFee` option to the wallet config. This will be enforced in the `signTransaction` and `sendTransaction` functions.

## Motivation and Context

We currently have a `transferMaxFee` check when calling `transfer()`, and are missing max fee checks on the other functions.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1215286379832381