### PR TITLE
Remove private properties from type definitions.

### DIFF
--- a/types/src/wallet-manager.d.ts
+++ b/types/src/wallet-manager.d.ts
@@ -21,8 +21,6 @@ export default abstract class WalletManager {
      * @param {WalletConfig} [config] - The wallet configuration.
      */
     constructor(seed: string | Uint8Array, config?: WalletConfig);
-    /** @private */
-    private _seed;
     /**
      * The wallet configuration.
      *


### PR DESCRIPTION
# Description
PR removes the _seed private property from the .d.ts type definitions to avoid clashes when using typescript.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
-

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first. -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce. -->
<!--- Please link to the issue here: -->
PR fixes the following issue: -

## Type of change
<!-- Select the most suitable choice and remove the others from the checklist. -->

- [x] Bug fix (non-breaking change which fixes an issue)
