### PR TITLE
remove signTransaction from ISigner interface, update deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1189,13 +1189,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.9.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.3.tgz",
-      "integrity": "sha512-603BddQMv3pUcr4U2dhujk83N2tTDVr/34wII2B6bJy6g+8WD6yUb11jszNs0gdi4PesVWl7ABt8nYMVpnLUcg==",
+      "version": "26.0.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.0.1.tgz",
+      "integrity": "sha512-fc3KiUoBt6kie0N9bIW3E47vZsuaMf0PM2AaUpLCLT0s/LvX1nxAim6Fc049cNxODPpGm6qRAuUOB86SkRuPQw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": ">=7.24.0 <7.24.7"
+        "undici-types": "~8.3.0"
       }
     },
     "node_modules/@types/stack-utils": {
@@ -1223,9 +1223,9 @@
       "license": "MIT"
     },
     "node_modules/@ungap/structured-clone": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.1.tgz",
-      "integrity": "sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.2.tgz",
+      "integrity": "sha512-5jsZFwgR5rTdKwidH9Qmat75RKwqfpKlWWB1frDkljN127mwqBu8K0PYo7/hFpF03IEJpfVPpCQDY/eDx3iHvA==",
       "dev": true,
       "license": "ISC"
     },
@@ -1726,6 +1726,17 @@
       "integrity": "sha512-xNfGwUobaomCGMGAqohAekS3uMCj+4tvI4AoOaJnO7NfpN+dvFdkC5xkeQtmZzs2vxf2TR5J6i5FDd1ImCZERw==",
       "license": "Apache-2.0"
     },
+    "node_modules/bare-broadcast-channel": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/bare-broadcast-channel/-/bare-broadcast-channel-0.2.0.tgz",
+      "integrity": "sha512-MuAwdKWr4cSjNwqvbE3tA9Wn6w69q6iXYnP2Wb0nlDa6sKNSMSfY7LXkV4FzWlq9JFP9d0HkCAKPboTLKnUfWQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.0.0",
+        "bare-stream": "^2.7.0",
+        "bare-structured-clone": "^1.4.0"
+      }
+    },
     "node_modules/bare-buffer": {
       "version": "3.6.1",
       "resolved": "https://registry.npmjs.org/bare-buffer/-/bare-buffer-3.6.1.tgz",
@@ -2000,9 +2011,9 @@
       }
     },
     "node_modules/bare-inspector": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/bare-inspector/-/bare-inspector-6.0.1.tgz",
-      "integrity": "sha512-rL+aKJ74FhF+6iJS2cV3C8js8nGF37H05ldiyMojgFP/N5eYShZ/mhSbTcDh1yriW5jndYd6xWQU0E/CE14Tiw==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/bare-inspector/-/bare-inspector-6.1.0.tgz",
+      "integrity": "sha512-PRxmZ4gF+K3TLzGubgRFvzdECybTCSKackgNsAdd4e7SdvICxMkGj+p5iX7bSKYSmgDnxgCR+2Z6UXmWykKhvw==",
       "license": "Apache-2.0",
       "dependencies": {
         "bare-events": "^2.1.0",
@@ -2012,7 +2023,7 @@
         "bare-ws": "^3.0.0"
       },
       "engines": {
-        "bare": ">=1.25.0"
+        "bare": ">=1.29.0"
       },
       "peerDependencies": {
         "bare-tcp": "*"
@@ -2039,19 +2050,20 @@
       "license": "Apache-2.0"
     },
     "node_modules/bare-module": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/bare-module/-/bare-module-6.2.0.tgz",
-      "integrity": "sha512-CoCTG8y8HKPnNW317OW1hynl28DasVPtbX033ZEAXk0Q3SYCUXi3OOnNAr6wTrDgMgpOsW0kl7Nifcom5GGH8Q==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/bare-module/-/bare-module-6.4.0.tgz",
+      "integrity": "sha512-Yn4V5g5EqGQL4LYUOmt7fjKzj2JPWyJOqE3lPoeZwfUH5rk4CKUfZj6JhDwbzhBYCqqmUgjgQ5aY8cihAPILLA==",
       "license": "Apache-2.0",
       "dependencies": {
         "bare-bundle": "^1.3.0",
         "bare-module-lexer": "^1.0.0",
         "bare-module-resolve": "^1.8.0",
         "bare-path": "^3.0.0",
+        "bare-type-stripper": "^0.1.2",
         "bare-url": "^2.0.1"
       },
       "engines": {
-        "bare": ">=1.23.0"
+        "bare": ">=1.29.4"
       },
       "peerDependencies": {
         "bare-buffer": "*"
@@ -2063,9 +2075,9 @@
       }
     },
     "node_modules/bare-module-lexer": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/bare-module-lexer/-/bare-module-lexer-1.5.2.tgz",
-      "integrity": "sha512-kfElvxEitooj2gsAO+GkL0Ikok2k05FCnqhvcvYuSMLmuxYNHouIzgNHgxSfIUl3hnhnrAkX7YdM1vBp5SU8yA==",
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/bare-module-lexer/-/bare-module-lexer-1.5.3.tgz",
+      "integrity": "sha512-URLPza0jP3aVzeIX5MDKAl5tGH7zLW1dNCVmSvg3so6PM0/HhoDk2AfVQVeTFJ1xZaxFfaLuGa43q8uC1MmY1g==",
       "license": "Apache-2.0",
       "dependencies": {
         "require-addon": "^1.0.2"
@@ -2132,9 +2144,9 @@
       }
     },
     "node_modules/bare-node-runtime": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/bare-node-runtime/-/bare-node-runtime-1.4.0.tgz",
-      "integrity": "sha512-/mYhg/vJSnrBlz1CFKjgihT7PoChbYFsxjUf7mEas7997ty/dQ4plyzhn17TF/u163Of8hvil+ZWFF7amApl9A==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bare-node-runtime/-/bare-node-runtime-1.5.0.tgz",
+      "integrity": "sha512-eMRq9WDYd+E0IZ8EG/8iCozZJl511z6vp7kxZyxjDw77ggOZ7bThFpJ72Kztjs8sh0hoe+xhFyZmoqAdVE/Ziw==",
       "license": "Apache-2.0",
       "dependencies": {
         "bare-abort-controller": "^1.0.0",
@@ -2218,10 +2230,16 @@
         "bare": ">=1.16.0"
       }
     },
+    "node_modules/bare-posix": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/bare-posix/-/bare-posix-1.0.1.tgz",
+      "integrity": "sha512-b4quA8dyRVvX0aFIAIiev5zFATHwIUGr42Gmt+CqiBNg/bdsNkrj4bbkeotMOMiljJS4DCME5kywJO/TFwKo1A==",
+      "license": "Apache-2.0"
+    },
     "node_modules/bare-process": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/bare-process/-/bare-process-4.4.1.tgz",
-      "integrity": "sha512-JfcTtymq6akqM2bdyTsP4A4GYJceBzb91k/ECmFps75uFf6uO33SM1bOZsRAqyRXExabsQJLn5S41NBl8HTM4A==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/bare-process/-/bare-process-4.5.0.tgz",
+      "integrity": "sha512-NTtYDiwleJjWWNg4+yzS6B/RovL/LLPHVvoOM+18W+dYAXCmky0zFfN66hqqBbrlGAlb52/QgKrdzPR3x1QyHA==",
       "license": "Apache-2.0",
       "dependencies": {
         "bare-abort": "^2.0.13",
@@ -2229,6 +2247,7 @@
         "bare-events": "^2.3.1",
         "bare-hrtime": "^2.0.0",
         "bare-os": "^3.7.1",
+        "bare-posix": "^1.0.1",
         "bare-signals": "^4.0.0",
         "bare-stdio": "^1.0.1"
       }
@@ -2268,13 +2287,13 @@
       }
     },
     "node_modules/bare-repl": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/bare-repl/-/bare-repl-6.0.2.tgz",
-      "integrity": "sha512-w2R+5LOrMl9UH/gcFjvdIpsB+SgyLr8cW4uJo5bAEzRbRpVA+ZTm8pMHYdj0uqIUBClP/6fkyW0MnB1XkxakmQ==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/bare-repl/-/bare-repl-6.1.0.tgz",
+      "integrity": "sha512-pVTbak3RQCUxC0Z4kiMjS0S+P5wJedU5947yV6rTtOmhmQ62GYdoruPMJGTcSONsX2KJd+lHzxVipoIXSfvfIw==",
       "license": "Apache-2.0",
       "dependencies": {
         "bare-inspect": "^3.0.0",
-        "bare-module": "^6.0.1",
+        "bare-module": "^6.4.0",
         "bare-os": "^3.0.1",
         "bare-path": "^3.0.0",
         "bare-pipe": "^4.0.0",
@@ -2284,9 +2303,9 @@
       }
     },
     "node_modules/bare-semver": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/bare-semver/-/bare-semver-1.0.3.tgz",
-      "integrity": "sha512-HS/A30bi2+PiRJfU6R4+Kp+6KeLSCSByjYM2iiobOKzLAvtu1CT+S8xWfiU7wz0erknjkUoC+yXy108tzIuP5Q==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/bare-semver/-/bare-semver-1.1.0.tgz",
+      "integrity": "sha512-1Hw5qJ7hXdVt3uPUqjeFTuxyvBUJauvz5A1I2jk8gzjZMHp04n//6nV9MDbG9CMw78JHY2lGV0w6s//LrASm2w==",
       "license": "Apache-2.0"
     },
     "node_modules/bare-signals": {
@@ -2328,11 +2347,12 @@
       }
     },
     "node_modules/bare-stream": {
-      "version": "2.13.2",
-      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.13.2.tgz",
-      "integrity": "sha512-2V5j0dOfxv3iIngIWMnW1O6UPXpeoU70HJzUJGVth/+RURhDyq7SEWTD70Y2SkUB0MQonYYWpIX3f85P/I22+Q==",
+      "version": "2.13.3",
+      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.13.3.tgz",
+      "integrity": "sha512-Kc+brLqvEqGkjyfiwJmImAOqLZL7OsoLKuavx+hJjgVV3nLTOjloJyPMFxjUPerGGHrNH0fLU06jjykMLWrERQ==",
       "license": "Apache-2.0",
       "dependencies": {
+        "b4a": "^1.8.1",
         "streamx": "^2.25.0",
         "teex": "^1.0.1"
       },
@@ -2371,9 +2391,9 @@
       }
     },
     "node_modules/bare-structured-clone": {
-      "version": "1.5.5",
-      "resolved": "https://registry.npmjs.org/bare-structured-clone/-/bare-structured-clone-1.5.5.tgz",
-      "integrity": "sha512-b1x++7qt6x7T0Rm8NAg/EnU13+rn3Gfglv8N5PGtFcfdi4yAfLJs/mLbrVfc+C66DFrO+CxdIsl1NcnE6Ra+xQ==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/bare-structured-clone/-/bare-structured-clone-1.6.0.tgz",
+      "integrity": "sha512-AZjEERyqF7kAuudlmgrweT2KwwWM0LsGG4Gx/bWyFwJrKU7E3wNG8c09z2DIrdw93p3vDtfOX8fyHOcXfy5m+g==",
       "license": "Apache-2.0",
       "dependencies": {
         "bare-buffer": "^3.6.0",
@@ -2453,9 +2473,9 @@
       }
     },
     "node_modules/bare-thread": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/bare-thread/-/bare-thread-1.2.2.tgz",
-      "integrity": "sha512-VuPKbGUwDzSNsOnbhQX+4rHP0JzKE9CrmYUjZ57Q6MteWfXQx1MvR7VODYDoA4dxb4LvBVhckafOTV0jYjhfcA==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/bare-thread/-/bare-thread-1.2.4.tgz",
+      "integrity": "sha512-MnqMCGVp2JJJNXgwUBC8hw+J4FrTeLkLgfCPPl5tQK6MbtV2Efi6LKK5v819VRY0da+AXlCbgssbAVge31NfRg==",
       "license": "Apache-2.0",
       "dependencies": {
         "bare-bundle": "^1.9.0",
@@ -2517,6 +2537,23 @@
         "bare": ">=1.2.0"
       }
     },
+    "node_modules/bare-type-stripper": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/bare-type-stripper/-/bare-type-stripper-0.1.2.tgz",
+      "integrity": "sha512-ArhqyRF9PramHfuSkZHp6DeMg8UdXWN2vjH0dvJ8PNJW15UDM6X/cSeT40R1IsKbyFgpM6+lZd2ZBlAKmKaGyg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "require-addon": "^1.0.2"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/bare-url": {
       "version": "2.4.5",
       "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.5.tgz",
@@ -2556,14 +2593,16 @@
       }
     },
     "node_modules/bare-worker": {
-      "version": "4.1.9",
-      "resolved": "https://registry.npmjs.org/bare-worker/-/bare-worker-4.1.9.tgz",
-      "integrity": "sha512-T+T0srkqXzniodEKvKWRaKaU1rA1NII9BX7Cd9rgnBGV1/FBiwwStDHVf3CMNmQI8d9H0xLwi/c35USYN90Fdw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/bare-worker/-/bare-worker-4.3.0.tgz",
+      "integrity": "sha512-aWwGexQlMqXWHH7GjvWrLUKI4o5ZPfNQVCr0QdY79JBu0hKLaRXvwos80YpCgKxl8eSaQtCEQHR0qRAxPvs8zA==",
       "license": "Apache-2.0",
       "dependencies": {
+        "bare-broadcast-channel": "^0.2.0",
         "bare-channel": "^5.1.5",
         "bare-events": "^2.2.1",
-        "bare-module": "^6.0.1",
+        "bare-module": "^6.4.0",
+        "bare-stream": "^2.13.3",
         "bare-thread": "^1.2.2"
       }
     },
@@ -2610,9 +2649,9 @@
       }
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.36",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.36.tgz",
-      "integrity": "sha512-lVq/Df7LXlO79MVaaUHztSwWiG9oXoWHlgvNS51v8Dpd4+G4/VIy6qYePTw31nAVls33nUtnfezYeLkYAak9dg==",
+      "version": "2.10.40",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.40.tgz",
+      "integrity": "sha512-BSSLZ9/Cjjv7Gtj5B68ZzXcXUg8iOf3fme+FCuh8rC/Go+Kmh8cox7M3A8dolou16s64QjLPOSdngh7GxXvkSw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -2658,9 +2697,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.28.2",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
-      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+      "version": "4.28.4",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.4.tgz",
+      "integrity": "sha512-MTc8i/x9jBQd1iMw2CFGS+rwMa07eYjLR0CCTLDACl9xhxy+nIs3KeML/biicXtk9JrZ6dnnTatmc7ErPXIxqw==",
       "dev": true,
       "funding": [
         {
@@ -2678,10 +2717,10 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.10.12",
-        "caniuse-lite": "^1.0.30001782",
-        "electron-to-chromium": "^1.5.328",
-        "node-releases": "^2.0.36",
+        "baseline-browser-mapping": "^2.10.38",
+        "caniuse-lite": "^1.0.30001799",
+        "electron-to-chromium": "^1.5.376",
+        "node-releases": "^2.0.48",
         "update-browserslist-db": "^1.2.3"
       },
       "bin": {
@@ -2719,9 +2758,9 @@
       }
     },
     "node_modules/builtins/node_modules/semver": {
-      "version": "7.8.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
-      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -2926,9 +2965,9 @@
       "license": "MIT"
     },
     "node_modules/compact-encoding": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/compact-encoding/-/compact-encoding-3.2.0.tgz",
-      "integrity": "sha512-cCe/FM8f/WuXkEVpsYEoSX3ht2tec7NSNOC8rZBv/sbdFzO3h2Z/JUmZwJQBhghKJNimJSkWM40YURhgU640jw==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/compact-encoding/-/compact-encoding-3.3.0.tgz",
+      "integrity": "sha512-e64XyzlBvTRJ3iScuU/U2w25Dglkm7fhrRbrGaHIwuTlNnzjRKMaQBCVl7mJRvZg7wI5a9wX1IVTXCuaAANNkw==",
       "license": "Apache-2.0",
       "dependencies": {
         "b4a": "^1.3.0"
@@ -3186,9 +3225,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.371",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.371.tgz",
-      "integrity": "sha512-e9htk9mAYL6AzmkEhSvVVw7IWGSBJ/Bqdn2eRyRLrj1g6sncN4WbFt5qnILYoCktktr45pyjIrOiRvBThQ808w==",
+      "version": "1.5.379",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.379.tgz",
+      "integrity": "sha512-v/qV5aV5EUA2pGilzUCq5/eyOloZAqDZBu9UMBIzgPpLlprjSR6zswsWBTv0KpqxLGUAZEwhO95ZCt7srymNVA==",
       "dev": true,
       "license": "ISC"
     },
@@ -3291,6 +3330,25 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/es-abstract-get": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/es-abstract-get/-/es-abstract-get-1.0.0.tgz",
+      "integrity": "sha512-6PMWXpdhshVvFp+FoWYs1EvG1Nj0tvk0dZM+XcK0xMEM1czRVcP6ohqPWHy6qPagSpC8j4+p89WXlT+xXJs/fg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.2",
+        "is-callable": "^1.2.7",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/es-define-property": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
@@ -3382,15 +3440,18 @@
       }
     },
     "node_modules/es-to-primitive": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.3.0.tgz",
-      "integrity": "sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==",
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.3.4.tgz",
+      "integrity": "sha512-yPDz7wqpg1/mmHLmS3tcfTfbw5f1eryXvyghYBffGdERwe+mV7ZcWzTR8LR17Kvqt3qfPurjlonmnq3MKXIOXw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "es-abstract-get": "^1.0.0",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
         "is-callable": "^1.2.7",
-        "is-date-object": "^1.0.5",
-        "is-symbol": "^1.0.4"
+        "is-date-object": "^1.1.0",
+        "is-symbol": "^1.1.1"
       },
       "engines": {
         "node": ">= 0.4"
@@ -3735,9 +3796,9 @@
       }
     },
     "node_modules/eslint-plugin-n/node_modules/semver": {
-      "version": "7.8.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
-      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -4279,18 +4340,21 @@
       }
     },
     "node_modules/function.prototype.name": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.8.tgz",
-      "integrity": "sha512-e5iwyodOHhbMr/yNrc7fDYG4qlbIvI5gajyzPnb5TCwyhjApznQh1BMFou9b30SevY43gCJKXycoCBjMbsuW0Q==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.2.0.tgz",
+      "integrity": "sha512-jObKIik1P2QjPHP5nz5BaOtUlfgS0fWo8IUByNXkM+o+02sJOi94em77GwJKQSJ3gfPHdgzLNrHc1uokV4P/ew==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.8",
-        "call-bound": "^1.0.3",
-        "define-properties": "^1.2.1",
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
         "functions-have-names": "^1.2.3",
-        "hasown": "^2.0.2",
-        "is-callable": "^1.2.7"
+        "has-property-descriptors": "^1.0.2",
+        "hasown": "^2.0.4",
+        "is-callable": "^1.2.7",
+        "is-document.all": "^1.0.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -4894,6 +4958,22 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-document.all": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-document.all/-/is-document.all-1.0.0.tgz",
+      "integrity": "sha512-+XSoyS05OdBbhFuELhgTCpFNHkpBOJqtsZfUFFpe5QTw+9Sjbh8zitxhQkYAo6wV7e1Vb8cAPvpCk9jGam/82g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -5236,9 +5316,9 @@
       }
     },
     "node_modules/istanbul-lib-instrument/node_modules/semver": {
-      "version": "7.8.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
-      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -5793,9 +5873,9 @@
       }
     },
     "node_modules/jest-snapshot/node_modules/semver": {
-      "version": "7.8.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
-      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -6166,9 +6246,9 @@
       }
     },
     "node_modules/make-dir/node_modules/semver": {
-      "version": "7.8.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
-      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -6267,9 +6347,9 @@
       "license": "MIT"
     },
     "node_modules/node-exports-info": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/node-exports-info/-/node-exports-info-1.6.0.tgz",
-      "integrity": "sha512-pyFS63ptit/P5WqUkt+UUfe+4oevH+bFeIiPPdfb0pFeYEu/1ELnJu5l+5EcTKYL5M7zaAa7S8ddywgXypqKCw==",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/node-exports-info/-/node-exports-info-1.6.2.tgz",
+      "integrity": "sha512-kXs9Go0cah0qHVV2v389IXQLdLCeE1xfFtjOAF+iobu0OIoG1pje8At2vMHyaPMiPMnG/LWP50twML21eMcAag==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6293,9 +6373,9 @@
       "license": "MIT"
     },
     "node_modules/node-releases": {
-      "version": "2.0.47",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.47.tgz",
-      "integrity": "sha512-Uzmd6LXpouKo8EUK68IjH4+E01w/hXyV3R3g/geCJo+rXLNfh1xucB+LOzYEOQPSiUK3h/xZf0cQGcSsmyL2Og==",
+      "version": "2.0.50",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.50.tgz",
+      "integrity": "sha512-J6l92tKHX6w8Jy5nO1Vuc01NoIiRGi/d6qBKVxh+IQ8Cr3b6HbVNfKiF8ZpFKufTwpwxMmce2W3iQZ861ZRyTg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7449,9 +7529,9 @@
       }
     },
     "node_modules/streamx": {
-      "version": "2.27.0",
-      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.27.0.tgz",
-      "integrity": "sha512-WZ189TKnHoAokYHvwzaAQMpd55cgUmFIcJFzBSgGcb886jau5DL+XdDhTWV4ps3FLvk+OORp0dLRTPsLZ21CSA==",
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.28.0.tgz",
+      "integrity": "sha512-1Yowhzjf0ivGMrTIkY9hav5TxobO9qIVqUE41fiCGMGgc3CLlf4MY+9AHmZqBWgDTue0fY9zWjYFVyf6Diuobw==",
       "license": "MIT",
       "dependencies": {
         "events-universal": "^1.0.0",
@@ -7884,9 +7964,9 @@
       }
     },
     "node_modules/udx-native": {
-      "version": "1.20.6",
-      "resolved": "https://registry.npmjs.org/udx-native/-/udx-native-1.20.6.tgz",
-      "integrity": "sha512-x2L/dPPEINPgURSPKCLahT3ooJ9p1qLXvj2YvIx30j95E0S6T+ghzroxmyedCbJqCFN2SQQ9QFrGKx96BJEn5g==",
+      "version": "1.20.7",
+      "resolved": "https://registry.npmjs.org/udx-native/-/udx-native-1.20.7.tgz",
+      "integrity": "sha512-FNG0QpnSt0us2xbLP5mmG5Q0UKdLYjKHuh2eR9VrJSFmoZMzeszYLLhK12+iq5x3eq/rgoGG/lLwPn7IDAr6pg==",
       "license": "Apache-2.0",
       "dependencies": {
         "b4a": "^1.5.0",
@@ -7918,9 +7998,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.24.6",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
-      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -8182,9 +8262,9 @@
       "license": "ISC"
     },
     "node_modules/yargs": {
-      "version": "17.7.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
-      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "version": "17.7.3",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.3.tgz",
+      "integrity": "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/src/signer.js
+++ b/src/signer.js
@@ -15,8 +15,6 @@
 
 import { NotImplementedError } from './errors.js'
 
-/** @typedef {import('./wallet-account-read-only.js').Transaction} Transaction */
-
 /**
  * A minimal, cross-chain signer interface.
  *
@@ -32,16 +30,6 @@ export class ISigner {
    */
   async derive (relPath) {
     throw new NotImplementedError('derive(relPath)')
-  }
-
-  /**
-   * Signs a transaction.
-   *
-   * @param {Transaction} tx - The transaction to sign.
-   * @returns {Promise<unknown>} The signed transaction.
-   */
-  async signTransaction (tx) {
-    throw new NotImplementedError('signTransaction(tx)')
   }
 
   /**

--- a/tests/wallet-manager.test.js
+++ b/tests/wallet-manager.test.js
@@ -9,10 +9,6 @@ class DummySigner {
     return this
   }
 
-  async signTransaction (tx) {
-    return null
-  }
-
   async getAddress () {
     return 'dummy-address'
   }

--- a/types/src/signer.d.ts
+++ b/types/src/signer.d.ts
@@ -13,13 +13,6 @@ export class ISigner {
      */
     derive(relPath: string): Promise<ISigner>;
     /**
-     * Signs a transaction.
-     *
-     * @param {Transaction} tx - The transaction to sign.
-     * @returns {Promise<unknown>} The signed transaction.
-     */
-    signTransaction(tx: Transaction): Promise<unknown>;
-    /**
      * Returns the signer's address.
      *
      * @returns {Promise<string>} The address.
@@ -30,5 +23,4 @@ export class ISigner {
      */
     dispose(): void;
 }
-export type Transaction = import("./wallet-account-read-only.js").Transaction;
 export type SignerError = import("./errors.js").SignerError;


### PR DESCRIPTION
# Description
Removes `signTransaction` from the base `ISigner` interface so concrete signer implementations are free to use their chain-idiomatic signing method (e.g., `signPsbt` for BTC, `signTransaction` for EVM).

## Motivation and Context
Forcing a uniform `signTransaction` name on the base contract was misleading, the operation has genuinely divergent naming across chains, also the input type varies a lot. Keeping `ISigner` minimal and chain-agnostic lets implementers follow each ecosystem's conventions without aliasing.

## Type of change

- [x] Feature removal (removal of a method from a public base interface)
