### PR TITLE
Release: v1.0.0-beta.12

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tetherto/wdk-wallet",
-  "version": "1.0.0-beta.11",
+  "version": "1.0.0-beta.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tetherto/wdk-wallet",
-      "version": "1.0.0-beta.11",
+      "version": "1.0.0-beta.12",
       "license": "Apache-2.0",
       "dependencies": {
         "bare-node-runtime": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tetherto/wdk-wallet",
-  "version": "1.0.0-beta.11",
+  "version": "1.0.0-beta.12",
   "description": "A simple package to manage BIP-32 wallets.",
   "keywords": [
     "wdk",


### PR DESCRIPTION
- Bump version to 1.0.0-beta.12

### Changes since v1.0.0-beta.11
- chore: remove `signTransaction` from `ISigner` interface so concrete signers can use chain-idiomatic signing methods (#47)

### Dependency updates
- Lockfile refreshed in #47 (`bare-node-runtime` ^1.4.0)
- npm audit fix skipped — js-yaml advisory in jest dev dependency chain requires breaking jest downgrade

Made with [Cursor](https://cursor.com)