### PR TITLE
fix(types): default TSignedTransaction generic to unknown

### DIFF
--- a/src/wallet-account.js
+++ b/src/wallet-account.js
@@ -31,7 +31,7 @@ import { NotImplementedError } from './errors.js'
 
 /**
  * @interface
- * @template TSignedTransaction
+ * @template [TSignedTransaction=unknown]
  */
 export class IWalletAccount extends IWalletAccountReadOnly {
   /**

--- a/types/src/wallet-account.d.ts
+++ b/types/src/wallet-account.d.ts
@@ -1,5 +1,5 @@
 /** @interface */
-export interface IWalletAccount<TSignedTransaction> extends IWalletAccountReadOnly {
+export interface IWalletAccount<TSignedTransaction = unknown> extends IWalletAccountReadOnly {
     /**
      * The derivation path's index of this account.
      *


### PR DESCRIPTION
## Summary

`IWalletAccount<TSignedTransaction>` was made generic in `1.0.0-beta.12` (via #45) with **no default type argument**. Every bare `IWalletAccount` reference — inside this module's own `.d.ts` files, in `@tetherto/wdk-wallet-evm`, and in `@tetherto/wdk-core` — now fails to compile under any consumer's TypeScript project:

```
error TS2314: Generic type 'IWalletAccount<TSignedTransaction>' requires 1 type argument(s).
```

This blocks anything that consumes those `.d.ts` files, including the WDK docs TypeScript snippets we're preparing for the policy engine documentation.

## Fix

Add a default `unknown` to the template parameter in `src/wallet-account.js`:

```diff
- * @template TSignedTransaction
+ * @template [TSignedTransaction=unknown]
```

Which emits as `IWalletAccount<TSignedTransaction = unknown>` in the `.d.ts`. Bare references (`IWalletAccount` without `<...>`) automatically resolve to `IWalletAccount<unknown>`, restoring compatibility with every existing call site.

## Scope

- 1 line of JSDoc in `src/wallet-account.js`
- 1 line in `types/src/wallet-account.d.ts` (surgically edited to avoid unrelated regeneration drift — the rest of `types/` is left as-is)

## Non-goals

The rest of `types/` shows drift when regenerated fresh under the pinned tsc 5.8.3 (interfaces emitted as classes, typedef imports rearranged, ~500 lines of noise). That's real but orthogonal to this fix — worth its own PR to run `build:types` on `main` and commit the clean baseline.

## Test plan

- [x] `npm run lint` — clean
- [x] `npm test` — 19/19 passing
- [x] Verified `.d.ts` emits `IWalletAccount<TSignedTransaction = unknown>`
- [x] Verified downstream: overlaid into `wdk-core/node_modules` and re-ran the docs snippet TS check — the "requires 1 type argument(s)" errors are gone

## Marked as draft

Opening as draft since this crosses module boundaries. Happy to iterate before it's marked ready for review.