### PR TITLE
Add `minAmountOut` to the swidge and swap interface

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tetherto/wdk-wallet",
-  "version": "1.0.0-beta.13",
+  "version": "1.0.0-beta.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tetherto/wdk-wallet",
-      "version": "1.0.0-beta.13",
+      "version": "1.0.0-beta.14",
       "license": "Apache-2.0",
       "dependencies": {
         "bare-node-runtime": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tetherto/wdk-wallet",
-  "version": "1.0.0-beta.13",
+  "version": "1.0.0-beta.14",
   "description": "A simple package to manage BIP-32 wallets.",
   "keywords": [
     "wdk",

--- a/src/protocols/swap-protocol.js
+++ b/src/protocols/swap-protocol.js
@@ -33,6 +33,7 @@ import { NotImplementedError } from '../errors.js'
  * @property {string} tokenIn - The address of the token to sell.
  * @property {string} tokenOut - The address of the token to buy.
  * @property {string} [to] - The address that will receive the output tokens. If not set, the account itself will receive the funds.
+ * @property {number | bigint} [minAmountOut] - The minimum acceptable amount of destination tokens to receive (in base unit).
  */
 
 /**

--- a/src/protocols/swidge-protocol.js
+++ b/src/protocols/swidge-protocol.js
@@ -54,6 +54,7 @@ import { NotImplementedError } from '../errors.js'
  * @property {string} [recipient] - The address that will receive the output tokens.
  * @property {string} [refundAddress] - The address that will receive refunds if the tx cannot complete.
  * @property {number} [slippage] - The maximum acceptable slippage as a decimal (e.g., 0.01 for 1%).
+ * @property {number | bigint} [minAmountOut] - The minimum acceptable amount of destination tokens to receive (in base unit).
  */
 
 /**
@@ -270,7 +271,8 @@ export default class SwidgeProtocol {
       toToken: options.tokenOut,
       recipient: options.to,
       fromTokenAmount: options.tokenInAmount,
-      toTokenAmount: options.tokenOutAmount
+      toTokenAmount: options.tokenOutAmount,
+      minAmountOut: options.minAmountOut
     })
     const fee = result.fees.reduce((acc, f) => acc + f.amount, 0n)
     return { hash: result.id, fee, tokenInAmount: result.fromTokenAmount, tokenOutAmount: result.toTokenAmount }
@@ -289,7 +291,8 @@ export default class SwidgeProtocol {
       toToken: options.tokenOut,
       recipient: options.to,
       fromTokenAmount: options.tokenInAmount,
-      toTokenAmount: options.tokenOutAmount
+      toTokenAmount: options.tokenOutAmount,
+      minAmountOut: options.minAmountOut
     })
     const fee = result.fees.reduce((acc, f) => acc + f.amount, 0n)
     return { fee, tokenInAmount: result.fromTokenAmount, tokenOutAmount: result.toTokenAmount }

--- a/types/src/protocols/swap-protocol.d.ts
+++ b/types/src/protocols/swap-protocol.d.ts
@@ -86,6 +86,10 @@ type SwapCommonOptions = {
      * - The address that will receive the output tokens. If not set, the account itself will receive the funds.
      */
     to?: string;
+    /**
+     * - The minimum acceptable amount of destination tokens to receive (in base unit).
+     */
+    minAmountOut?: number | bigint;
 };
 type SwapBuyOptions = {
     /**

--- a/types/src/protocols/swidge-protocol.d.ts
+++ b/types/src/protocols/swidge-protocol.d.ts
@@ -199,6 +199,10 @@ export type SwidgeCommonOptions = {
      * - The maximum acceptable slippage as a decimal (e.g., 0.01 for 1%).
      */
     slippage?: number | undefined;
+    /**
+     * - The minimum acceptable amount of destination tokens to receive (in base unit).
+     */
+    minAmountOut?: number | bigint;
 };
 export type SwidgeExactInOptions = {
     /**

--- a/types/src/protocols/swidge-protocol.d.ts
+++ b/types/src/protocols/swidge-protocol.d.ts
@@ -85,6 +85,7 @@ export default abstract class SwidgeProtocol implements ISwidgeProtocol, ISwapPr
      *
      * @param {SwapOptions} options - The swap's options.
      * @returns {Promise<SwapResult>} The swap's result.
+     * @throws {Error} If no account, or a read-only account was given at construction.
      */
     swap(options: SwapOptions): Promise<SwapResult>;
     /**
@@ -92,6 +93,7 @@ export default abstract class SwidgeProtocol implements ISwidgeProtocol, ISwapPr
      *
      * @param {SwapOptions} options - The swap's options.
      * @returns {Promise<Omit<SwapResult, 'hash'>>} The swap's quotes.
+     * @throws {Error} If no account was given at construction.
      */
     quoteSwap(options: SwapOptions): Promise<Omit<SwapResult, "hash">>;
     /**
@@ -99,6 +101,7 @@ export default abstract class SwidgeProtocol implements ISwidgeProtocol, ISwapPr
      *
      * @param {BridgeOptions} options - The bridge's options.
      * @returns {Promise<BridgeResult>} The bridge's result.
+     * @throws {Error} If no account, or a read-only account was given at construction.
      */
     bridge(options: BridgeOptions): Promise<BridgeResult>;
     /**
@@ -106,6 +109,7 @@ export default abstract class SwidgeProtocol implements ISwidgeProtocol, ISwapPr
      *
      * @param {BridgeOptions} options - The bridge's options.
      * @returns {Promise<Omit<BridgeResult, 'hash'>>} The bridge's quotes.
+     * @throws {Error} If no account was given at construction.
      */
     quoteBridge(options: BridgeOptions): Promise<Omit<BridgeResult, "hash">>;
     /**
@@ -116,6 +120,7 @@ export default abstract class SwidgeProtocol implements ISwidgeProtocol, ISwapPr
      * @abstract
      * @param {SwidgeOptions} options - The swidge options.
      * @returns {Promise<SwidgeQuote>} The quoted swidge details.
+     * @throws {Error} If no account was given at construction.
      */
     abstract quoteSwidge(options: SwidgeOptions): Promise<SwidgeQuote>;
     /**
@@ -125,6 +130,7 @@ export default abstract class SwidgeProtocol implements ISwidgeProtocol, ISwapPr
      * @param {SwidgeOptions} options - The swidge options.
      * @param {SwidgeProtocolConfig} [config] - Optional provider-specific execution configuration.
      * @returns {Promise<SwidgeResult>} The swidge execution result.
+     * @throws {Error} If no account, or a read-only account was given at construction.
      */
     abstract swidge(options: SwidgeOptions, config?: SwidgeProtocolConfig): Promise<SwidgeResult>;
     /**
@@ -264,6 +270,11 @@ export type SwidgeTransaction = {
      */
     type?: "other" | "source" | "destination" | "approval" | "refund" | undefined;
 };
+/**
+ * Non-binding quote for a swidge operation.
+ * Providers that internally decompose the operation into multiple sequential transactions
+ * should encapsulate that decomposition behind a single quote.
+ */
 export type SwidgeQuote = {
     /**
      * - The amount of source tokens to spend.


### PR DESCRIPTION
# Description
In cases where we want to quote first and then swidge, passing a `minAmountOut` from the quote data to the `swidge` call would ensure users are getting the quote that they approved

## Type of change
<!-- Select the most suitable choice and remove the others from the checklist. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1216404093755487