### PR TITLE
Release: v1.0.0-beta.16

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tetherto/wdk-wallet",
-  "version": "1.0.0-beta.15",
+  "version": "1.0.0-beta.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tetherto/wdk-wallet",
-      "version": "1.0.0-beta.15",
+      "version": "1.0.0-beta.16",
       "license": "Apache-2.0",
       "dependencies": {
         "bare-node-runtime": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tetherto/wdk-wallet",
-  "version": "1.0.0-beta.15",
+  "version": "1.0.0-beta.16",
   "description": "A simple package to manage BIP-32 wallets.",
   "keywords": [
     "wdk",


### PR DESCRIPTION
- Bump version to 1.0.0-beta.16

### Changes since v1.0.0-beta.15
- Add multisig account wallet interfaces (#32)
- `IWalletAccountMultisig` / `IWalletAccountReadOnlyMultisig` with propose, approve, execute flows
- Chain-agnostic `IMultisigTransport` with generic payload types and `toTransportJson` helper
- Shared error taxonomy adoption; proposal status enum; owner management types
- Refactor read-only account hierarchy (`wallet-account-read-only-simple`)

### Dependency updates
- None (version bump only; lockfile synced)