### PR TITLE
Add waitForTransaction method

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,6 +20,10 @@
 /** @typedef {import('./src/wallet-account-read-only.js').TransactionResult} TransactionResult */
 /** @typedef {import('./src/wallet-account-read-only.js').TransferOptions} TransferOptions */
 /** @typedef {import('./src/wallet-account-read-only.js').TransferResult} TransferResult */
+/** @typedef {import('./src/wallet-account-read-only.js').Finality} Finality */
+/** @typedef {import('./src/wallet-account-read-only.js').TransactionReceipt} TransactionReceipt */
+/** @typedef {import('./src/wallet-account-read-only.js').WaitForTransactionTarget} WaitForTransactionTarget */
+/** @typedef {import('./src/wallet-account-read-only.js').WaitForTransactionOptions} WaitForTransactionOptions */
 
 /** @typedef {import('./src/wallet-account.js').KeyPair} KeyPair */
 
@@ -37,7 +41,10 @@ export {
   SignerError,
   UnsupportedOperationError,
   ValueError,
-  NoSuchElementError
+  NoSuchElementError,
+  TransactionFailedError,
+  TransactionDroppedError,
+  TransactionConfirmationTimeoutError
 } from './src/errors.js'
 
 export { ISigner } from './src/signer.js'

--- a/index.js
+++ b/index.js
@@ -20,10 +20,10 @@
 /** @typedef {import('./src/wallet-account-read-only.js').TransactionResult} TransactionResult */
 /** @typedef {import('./src/wallet-account-read-only.js').TransferOptions} TransferOptions */
 /** @typedef {import('./src/wallet-account-read-only.js').TransferResult} TransferResult */
-/** @typedef {import('./src/wallet-account-read-only.js').Finality} Finality */
-/** @typedef {import('./src/wallet-account-read-only.js').TransactionReceipt} TransactionReceipt */
-/** @typedef {import('./src/wallet-account-read-only.js').WaitForTransactionTarget} WaitForTransactionTarget */
-/** @typedef {import('./src/wallet-account-read-only.js').WaitForTransactionOptions} WaitForTransactionOptions */
+/** @typedef {import('./src/wallet-account-read-only-simple.js').Finality} Finality */
+/** @typedef {import('./src/wallet-account-read-only-simple.js').TransactionReceipt} TransactionReceipt */
+/** @typedef {import('./src/wallet-account-read-only-simple.js').WaitForTransactionTarget} WaitForTransactionTarget */
+/** @typedef {import('./src/wallet-account-read-only-simple.js').WaitForTransactionOptions} WaitForTransactionOptions */
 
 /** @typedef {import('./src/wallet-account.js').KeyPair} KeyPair */
 

--- a/index.js
+++ b/index.js
@@ -42,9 +42,7 @@ export {
   UnsupportedOperationError,
   ValueError,
   NoSuchElementError,
-  TransactionFailedError,
-  TransactionDroppedError,
-  TransactionConfirmationTimeoutError
+  TimeoutError
 } from './src/errors.js'
 
 export { ISigner } from './src/signer.js'

--- a/index.js
+++ b/index.js
@@ -31,7 +31,8 @@ export { default } from './src/wallet-manager.js'
 
 export {
   default as WalletAccountReadOnly,
-  IWalletAccountReadOnly
+  IWalletAccountReadOnly,
+  FINALITY
 } from './src/wallet-account-read-only.js'
 
 export { IWalletAccount } from './src/wallet-account.js'

--- a/src/errors.js
+++ b/src/errors.js
@@ -82,19 +82,14 @@ export class NoSuchElementError extends Error {
 
 export class TimeoutError extends Error {
   /**
-   * Create a new timeout error. Thrown when a transaction does not reach the
-   * requested finality target within the timeout.
+   * Create a new timeout error. Thrown when an operation does not complete
+   * within its allotted time.
    *
-   * @param {string} hash - The transaction's hash.
-   * @param {string} target - The requested finality target.
-   * @param {import('./wallet-account-read-only.js').TransactionReceipt | null} [receipt] - The last-seen receipt, or null if never seen.
+   * @param {string} message - The error's message.
    */
-  constructor (hash, target, receipt = null) {
-    super(`Transaction '${hash}' did not reach '${target}' within the timeout.`)
+  constructor (message) {
+    super(message)
 
     this.name = 'TimeoutError'
-
-    /** @type {import('./wallet-account-read-only.js').TransactionReceipt | null} */
-    this.receipt = receipt
   }
 }

--- a/src/errors.js
+++ b/src/errors.js
@@ -80,46 +80,10 @@ export class NoSuchElementError extends Error {
   }
 }
 
-export class TransactionFailedError extends Error {
+export class TimeoutError extends Error {
   /**
-   * Create a new transaction failed error. Thrown when a transaction lands on
-   * chain but its execution reverts.
-   *
-   * @param {string} hash - The transaction's hash.
-   * @param {import('./wallet-account-read-only.js').TransactionReceipt} [receipt] - The failed transaction's receipt.
-   */
-  constructor (hash, receipt) {
-    super(`Transaction '${hash}' failed.`)
-
-    this.name = 'TransactionFailedError'
-
-    /** @type {import('./wallet-account-read-only.js').TransactionReceipt | undefined} */
-    this.receipt = receipt
-  }
-}
-
-export class TransactionDroppedError extends Error {
-  /**
-   * Create a new transaction dropped error. Thrown when a transaction is evicted
-   * or replaced and never lands on chain.
-   *
-   * @param {string} hash - The transaction's hash.
-   * @param {import('./wallet-account-read-only.js').TransactionReceipt} [receipt] - The dropped transaction's receipt.
-   */
-  constructor (hash, receipt) {
-    super(`Transaction '${hash}' was dropped.`)
-
-    this.name = 'TransactionDroppedError'
-
-    /** @type {import('./wallet-account-read-only.js').TransactionReceipt | undefined} */
-    this.receipt = receipt
-  }
-}
-
-export class TransactionConfirmationTimeoutError extends Error {
-  /**
-   * Create a new transaction confirmation timeout error. Thrown when a
-   * transaction does not reach the requested finality target within the timeout.
+   * Create a new timeout error. Thrown when a transaction does not reach the
+   * requested finality target within the timeout.
    *
    * @param {string} hash - The transaction's hash.
    * @param {string} target - The requested finality target.
@@ -128,7 +92,7 @@ export class TransactionConfirmationTimeoutError extends Error {
   constructor (hash, target, receipt = null) {
     super(`Transaction '${hash}' did not reach '${target}' within the timeout.`)
 
-    this.name = 'TransactionConfirmationTimeoutError'
+    this.name = 'TimeoutError'
 
     /** @type {import('./wallet-account-read-only.js').TransactionReceipt | null} */
     this.receipt = receipt

--- a/src/errors.js
+++ b/src/errors.js
@@ -79,3 +79,58 @@ export class NoSuchElementError extends Error {
     this.name = 'NoSuchElementError'
   }
 }
+
+export class TransactionFailedError extends Error {
+  /**
+   * Create a new transaction failed error. Thrown when a transaction lands on
+   * chain but its execution reverts.
+   *
+   * @param {string} hash - The transaction's hash.
+   * @param {import('./wallet-account-read-only.js').TransactionReceipt} [receipt] - The failed transaction's receipt.
+   */
+  constructor (hash, receipt) {
+    super(`Transaction '${hash}' failed.`)
+
+    this.name = 'TransactionFailedError'
+
+    /** @type {import('./wallet-account-read-only.js').TransactionReceipt | undefined} */
+    this.receipt = receipt
+  }
+}
+
+export class TransactionDroppedError extends Error {
+  /**
+   * Create a new transaction dropped error. Thrown when a transaction is evicted
+   * or replaced and never lands on chain.
+   *
+   * @param {string} hash - The transaction's hash.
+   * @param {import('./wallet-account-read-only.js').TransactionReceipt} [receipt] - The dropped transaction's receipt.
+   */
+  constructor (hash, receipt) {
+    super(`Transaction '${hash}' was dropped.`)
+
+    this.name = 'TransactionDroppedError'
+
+    /** @type {import('./wallet-account-read-only.js').TransactionReceipt | undefined} */
+    this.receipt = receipt
+  }
+}
+
+export class TransactionConfirmationTimeoutError extends Error {
+  /**
+   * Create a new transaction confirmation timeout error. Thrown when a
+   * transaction does not reach the requested finality target within the timeout.
+   *
+   * @param {string} hash - The transaction's hash.
+   * @param {string} target - The requested finality target.
+   * @param {import('./wallet-account-read-only.js').TransactionReceipt | null} [receipt] - The last-seen receipt, or null if never seen.
+   */
+  constructor (hash, target, receipt = null) {
+    super(`Transaction '${hash}' did not reach '${target}' within the timeout.`)
+
+    this.name = 'TransactionConfirmationTimeoutError'
+
+    /** @type {import('./wallet-account-read-only.js').TransactionReceipt | null} */
+    this.receipt = receipt
+  }
+}

--- a/src/wallet-account-read-only-simple.js
+++ b/src/wallet-account-read-only-simple.js
@@ -16,6 +16,44 @@
 import { NotImplementedError } from './errors.js'
 
 /**
+ * A normalized, cross-chain transaction finality level.
+ *
+ * - `pending`: seen, not settled (mempool / processed / in-flight).
+ * - `confirmed`: settled, reversible only under extreme conditions.
+ * - `final`: irreversible per the chain's own guarantees.
+ * - `dropped`: evicted / replaced, never landed.
+ *
+ * @typedef {'pending' | 'confirmed' | 'final' | 'dropped'} Finality
+ */
+
+/**
+ * A normalized, cross-chain transaction receipt. Blockchain modules extend this
+ * type with their own native receipt fields (e.g. `confirmations`, the raw
+ * transaction and receipt objects, etc.).
+ *
+ * @typedef {Object} TransactionReceipt
+ * @property {string} hash - The transaction's identifier (hash / signature / lt:hash).
+ * @property {Finality} finality - The transaction's finality level.
+ * @property {boolean} [success] - The execution's result (not set if the transaction is still pending or it has been dropped).
+ * @property {number} [block] - A reference to the including block (block number / height / slot / masterchain seqno).
+ * @property {bigint} [fee] - The fee paid, when known.
+ */
+
+/**
+ * The finality level to wait for.
+ *
+ * @typedef {'confirmed' | 'final'} WaitForTransactionTarget
+ */
+
+/**
+ * @typedef {Object} WaitForTransactionOptions
+ * @property {WaitForTransactionTarget} [target] - The finality target to wait for (default: 'confirmed').
+ * @property {number} [timeout] - The total time budget in milliseconds before giving up (default: 60000).
+ * @property {number} [interval] - The poll cadence in milliseconds (default: 4000).
+ * @property {number} [maxPollErrors] - How many consecutive getTransaction() failures to tolerate before rethrowing (default: 3).
+ */
+
+/**
  * The read-only members shared by every wallet account, single-signer or multisig.
  *
  * This is an internal base interface: it is not exported from the package entry point.
@@ -68,10 +106,35 @@ export class IWalletAccountReadOnlySimple {
   /**
    * Returns a transaction's receipt.
    *
+   * @deprecated Use {@link getTransaction} instead, which returns a normalized, finality-based receipt. The native receipt fields remain available on each module's extended return type.
    * @param {string} hash - The transaction's hash.
    * @returns {Promise<unknown | null>} The receipt, or null if the transaction has not been included in a block yet.
    */
   async getTransactionReceipt (hash) {
     throw new NotImplementedError('getTransactionReceipt(hash)')
+  }
+
+  /**
+   * Returns a normalized, finality-based receipt for a transaction.
+   *
+   * @param {string} hash - The transaction's identifier (hash / signature / lt:hash).
+   * @returns {Promise<TransactionReceipt>} The normalized receipt.
+   * @throws {ValueError} If the hash is not a valid identifier.
+   * @throws {NoSuchElementError} If no transaction has been found for the given hash.
+   */
+  async getTransaction (hash) {
+    throw new NotImplementedError('getTransaction(hash)')
+  }
+
+  /**
+   * Blocks until a transaction reaches a terminal state (the requested finality target or `dropped`), or times out.
+   *
+   * @param {string} hash - The transaction's identifier.
+   * @param {WaitForTransactionOptions} [options] - The wait options.
+   * @returns {Promise<TransactionReceipt>} The terminal receipt.
+   * @throws {TimeoutError} If the target is not reached before the timeout.
+   */
+  async waitForTransaction (hash, options) {
+    throw new NotImplementedError('waitForTransaction(hash, options)')
   }
 }

--- a/src/wallet-account-read-only-simple.js
+++ b/src/wallet-account-read-only-simple.js
@@ -48,8 +48,8 @@ import { NotImplementedError } from './errors.js'
 /**
  * @typedef {Object} WaitForTransactionOptions
  * @property {WaitForTransactionTarget} [target] - The finality target to wait for (default: 'confirmed').
- * @property {number} [timeout] - The total time budget in milliseconds before giving up (default: 60000).
- * @property {number} [interval] - The poll cadence in milliseconds (default: 4000).
+ * @property {number} [timeout] - The total time budget in milliseconds before giving up. If omitted, the account's `defaultWaitTimeout` is used.
+ * @property {number} [interval] - The poll cadence in milliseconds. If omitted, the account's `defaultWaitInterval` is used.
  * @property {number} [maxPollErrors] - How many consecutive getTransaction() failures to tolerate before rethrowing (default: 3).
  */
 

--- a/src/wallet-account-read-only.js
+++ b/src/wallet-account-read-only.js
@@ -93,8 +93,8 @@ export const FINALITY = {
 /**
  * @typedef {Object} WaitForTransactionOptions
  * @property {WaitForTransactionTarget} [target] - The finality target to wait for (default: 'confirmed').
- * @property {number} [timeout] - The total time budget in milliseconds before giving up (default: per-module).
- * @property {number} [interval] - The poll cadence in milliseconds (default: per-module).
+ * @property {number} [timeout] - The total time budget in milliseconds before giving up (default: 60000).
+ * @property {number} [interval] - The poll cadence in milliseconds (default: 4000).
  * @property {number} [maxPollErrors] - How many consecutive getTransaction() failures to tolerate before rethrowing (default: 3).
  */
 
@@ -161,6 +161,24 @@ export class IWalletAccountReadOnly extends IWalletAccountReadOnlySimple {
  * @implements {IWalletAccountReadOnly}
  */
 export default class WalletAccountReadOnly {
+  /**
+   * The default poll cadence for {@link waitForTransaction}, in milliseconds.
+   * Subclasses may override this to match their finality expectations.
+   *
+   * @protected
+   * @type {number}
+   */
+  static _DEFAULT_WAIT_INTERVAL = 4000
+
+  /**
+   * The default total time budget for {@link waitForTransaction}, in milliseconds.
+   * Subclasses may override this to match their finality expectations.
+   *
+   * @protected
+   * @type {number}
+   */
+  static _DEFAULT_WAIT_TIMEOUT = 60000
+
   /**
    * Creates a new read-only wallet account.
    *
@@ -292,8 +310,8 @@ export default class WalletAccountReadOnly {
   async waitForTransaction (hash, options = {}) {
     const {
       target = 'confirmed',
-      interval = this._defaultWaitInterval,
-      timeout = this._defaultWaitTimeout,
+      interval = this.constructor._DEFAULT_WAIT_INTERVAL,
+      timeout = this.constructor._DEFAULT_WAIT_TIMEOUT,
       maxPollErrors = 3
     } = options
 
@@ -337,26 +355,5 @@ export default class WalletAccountReadOnly {
 
       await new Promise(resolve => setTimeout(resolve, interval))
     }
-  }
-
-  /**
-  * The default poll cadence for {@link waitForTransaction}, in milliseconds.
-  *
-  * @protected
-  * @type {number}
-  */
-  get _defaultWaitInterval () {
-    return 4000
-  }
-
-  /**
-   * The default total time budget for {@link waitForTransaction}, in milliseconds.
-   * Modules override this to match their finality expectations.
-   *
-   * @protected
-   * @type {number}
-   */
-  get _defaultWaitTimeout () {
-    return 60000
   }
 }

--- a/src/wallet-account-read-only.js
+++ b/src/wallet-account-read-only.js
@@ -62,7 +62,7 @@ import { IWalletAccountReadOnlySimple } from './wallet-account-read-only-simple.
  * transaction and receipt objects, etc.).
  *
  * @typedef {Object} TransactionReceipt
- * @property {string} id - The transaction's identifier (hash / signature / lt:hash).
+ * @property {string} hash - The transaction's identifier (hash / signature / lt:hash).
  * @property {Finality} finality - The transaction's finality level.
  * @property {boolean} [success] - The execution's result (not set if the transaction is still pending or it has been dropped).
  * @property {number} [block] - A reference to the including block (block number / height / slot / masterchain seqno).

--- a/src/wallet-account-read-only.js
+++ b/src/wallet-account-read-only.js
@@ -15,9 +15,7 @@
 
 import {
   NotImplementedError,
-  TransactionFailedError,
-  TransactionDroppedError,
-  TransactionConfirmationTimeoutError
+  TimeoutError
 } from './errors.js'
 
 /**
@@ -296,17 +294,20 @@ export default class WalletAccountReadOnly {
   }
 
   /**
-   * Blocks until a transaction reaches the requested finality target, fails, is dropped, or times out.
+   * Blocks until a transaction reaches a terminal state (the requested finality
+   * target or `dropped`), or times out.
    *
    * The polling loop and target resolution are chain-agnostic: this method only
    * interprets the normalized receipt returned by {@link getTransaction}.
    *
+   * A reverted transaction still reaches its finality target, so it is returned
+   * like any other; callers dispatch on the receipt's `finality` and `success`
+   * fields to tell success, revert, and drop apart. Only a timeout throws.
+   *
    * @param {string} hash - The transaction's identifier.
    * @param {WaitForTransactionOptions} [options] - The wait options.
-   * @returns {Promise<TransactionReceipt>} The terminal receipt once the target is reached.
-   * @throws {TransactionFailedError} If the transaction lands but reverts (success === false). The receipt is exposed on `.receipt`.
-   * @throws {TransactionDroppedError} If the transaction is reported dropped on two consecutive polls. The receipt is exposed on `.receipt`.
-   * @throws {TransactionConfirmationTimeoutError} If the target is not reached before the timeout. The last-seen receipt (or null) is exposed on `.receipt`.
+   * @returns {Promise<TransactionReceipt>} The terminal receipt: the finality target reached (inspect `success` to tell success from revert), or `dropped`.
+   * @throws {TimeoutError} If the target is not reached before the timeout. The last-seen receipt (or null) is exposed on `.receipt`.
    */
   async waitForTransaction (hash, options = {}) {
     const {
@@ -337,15 +338,15 @@ export default class WalletAccountReadOnly {
         last = receipt
 
         if (receipt.finality === 'dropped') {
+          // Debounce a transient drop; only treat it as terminal once it persists.
           if (++droppedStreak >= 2) {
-            throw new TransactionDroppedError(hash, receipt)
+            return receipt
           }
         } else {
           droppedStreak = 0
 
-          if (receipt.success === false) {
-            throw new TransactionFailedError(hash, receipt)
-          }
+          // A reverted transaction still reaches its finality target: it is
+          // returned like any other, and the caller inspects `success`.
           if (this._meetsFinality(receipt.finality, target)) {
             return receipt
           }
@@ -355,7 +356,7 @@ export default class WalletAccountReadOnly {
       }
 
       if (Date.now() >= deadline) {
-        throw new TransactionConfirmationTimeoutError(hash, target, last)
+        throw new TimeoutError(hash, target, last)
       }
 
       await new Promise(resolve => setTimeout(resolve, interval))

--- a/src/wallet-account-read-only.js
+++ b/src/wallet-account-read-only.js
@@ -80,6 +80,7 @@ import {
  * @property {WaitForTransactionTarget} [target] - The finality target to wait for (default: 'confirmed').
  * @property {number} [timeout] - The total time budget in milliseconds before giving up (default: per-module).
  * @property {number} [interval] - The poll cadence in milliseconds (default: per-module).
+ * @property {number} [maxPollErrors] - How many consecutive getTransaction() failures to tolerate before rethrowing (default: 3).
  */
 
 /** @interface */
@@ -311,15 +312,26 @@ export default class WalletAccountReadOnly {
     const {
       target = 'confirmed',
       interval = this._defaultWaitInterval,
-      timeout = this._defaultWaitTimeout
+      timeout = this._defaultWaitTimeout,
+      maxPollErrors = 3
     } = options
 
     const deadline = Date.now() + timeout
     let last = null
     let droppedStreak = 0
+    let errorStreak = 0
 
     while (true) {
-      const receipt = await this.getTransaction(hash)
+      let receipt = null
+
+      try {
+        receipt = await this.getTransaction(hash)
+        errorStreak = 0
+      } catch (error) {
+        if (++errorStreak > maxPollErrors) {
+          throw error
+        }
+      }
 
       if (receipt) {
         last = receipt

--- a/src/wallet-account-read-only.js
+++ b/src/wallet-account-read-only.js
@@ -13,7 +13,12 @@
 // limitations under the License.
 'use strict'
 
-import { NotImplementedError } from './errors.js'
+import {
+  NotImplementedError,
+  TransactionFailedError,
+  TransactionDroppedError,
+  TransactionConfirmationTimeoutError
+} from './errors.js'
 
 /**
  * @typedef {Object} Transaction
@@ -38,6 +43,43 @@ import { NotImplementedError } from './errors.js'
  * @typedef {Object} TransferResult
  * @property {string} hash - The hash of the transfer operation.
  * @property {bigint} fee - The gas cost.
+ */
+
+/**
+ * A normalized, cross-chain transaction finality level.
+ *
+ * - `pending`: seen, not settled (mempool / processed / in-flight).
+ * - `confirmed`: settled, reversible only under extreme conditions.
+ * - `final`: irreversible per the chain's own guarantees.
+ * - `dropped`: evicted / replaced, never landed.
+ *
+ * @typedef {'pending' | 'confirmed' | 'final' | 'dropped'} Finality
+ */
+
+/**
+ * A normalized, cross-chain transaction receipt. Blockchain modules extend this
+ * type with their own native receipt fields (e.g. `confirmations`, the raw
+ * transaction and receipt objects, etc.).
+ *
+ * @typedef {Object} TransactionReceipt
+ * @property {string} id - The transaction's identifier (hash / signature / lt:hash).
+ * @property {Finality} finality - The transaction's finality level.
+ * @property {boolean | null} success - The execution result, or null while pending/dropped.
+ * @property {string | number} [blockRef] - A reference to the including block (block hash / slot / masterchain seqno).
+ * @property {bigint} [fee] - The fee paid, when known.
+ */
+
+/**
+ * The finality level to wait for.
+ *
+ * @typedef {'confirmed' | 'final'} WaitForTransactionTarget
+ */
+
+/**
+ * @typedef {Object} WaitForTransactionOptions
+ * @property {WaitForTransactionTarget} [target] - The finality target to wait for (default: 'confirmed').
+ * @property {number} [timeout] - The total time budget in milliseconds before giving up (default: per-module).
+ * @property {number} [interval] - The poll cadence in milliseconds (default: per-module).
  */
 
 /** @interface */
@@ -105,11 +147,33 @@ export class IWalletAccountReadOnly {
   /**
    * Returns a transaction's receipt.
    *
+   * @deprecated Use {@link getTransaction} instead, which returns a normalized, finality-based receipt. The native receipt fields remain available on each module's extended return type.
    * @param {string} hash - The transaction's hash.
    * @returns {Promise<unknown | null>} The receipt, or null if the transaction has not been included in a block yet.
    */
   async getTransactionReceipt (hash) {
     throw new NotImplementedError('getTransactionReceipt(hash)')
+  }
+
+  /**
+   * Returns a normalized, finality-based receipt for a transaction.
+   *
+   * @param {string} hash - The transaction's identifier (hash / signature / lt:hash).
+   * @returns {Promise<TransactionReceipt | null>} The normalized receipt, or null if the transaction is not known.
+   */
+  async getTransaction (hash) {
+    throw new NotImplementedError('getTransaction(hash)')
+  }
+
+  /**
+   * Blocks until a transaction reaches the requested finality target, fails, is dropped, or times out.
+   *
+   * @param {string} hash - The transaction's identifier.
+   * @param {WaitForTransactionOptions} [options] - The wait options.
+   * @returns {Promise<TransactionReceipt>} The terminal receipt.
+   */
+  async waitForTransaction (hash, options) {
+    throw new NotImplementedError('waitForTransaction(hash, options)')
   }
 }
 
@@ -210,11 +274,110 @@ export default class WalletAccountReadOnly {
   /**
    * Returns a transaction's receipt.
    *
+   * @deprecated Use {@link getTransaction} instead, which returns a normalized, finality-based receipt. The native receipt fields remain available on each module's extended return type.
    * @abstract
    * @param {string} hash - The transaction's hash.
    * @returns {Promise<unknown | null>} The receipt, or null if the transaction has not been included in a block yet.
    */
   async getTransactionReceipt (hash) {
     throw new NotImplementedError('getTransactionReceipt(hash)')
+  }
+
+  /**
+   * Returns a normalized, finality-based receipt for a transaction.
+   *
+   * @abstract
+   * @param {string} hash - The transaction's identifier (hash / signature / lt:hash).
+   * @returns {Promise<TransactionReceipt | null>} The normalized receipt, or null if the transaction is not known.
+   */
+  async getTransaction (hash) {
+    throw new NotImplementedError('getTransaction(hash)')
+  }
+
+  /**
+   * Blocks until a transaction reaches the requested finality target, fails, is dropped, or times out.
+   *
+   * The polling loop and target resolution are chain-agnostic: this method only
+   * interprets the normalized receipt returned by {@link getTransaction}.
+   *
+   * @param {string} hash - The transaction's identifier.
+   * @param {WaitForTransactionOptions} [options] - The wait options.
+   * @returns {Promise<TransactionReceipt>} The terminal receipt once the target is reached.
+   * @throws {TransactionFailedError} If the transaction lands but reverts (success === false). The receipt is exposed on `.receipt`.
+   * @throws {TransactionDroppedError} If the transaction is evicted or replaced. The receipt is exposed on `.receipt`.
+   * @throws {TransactionConfirmationTimeoutError} If the target is not reached before the timeout. The last-seen receipt (or null) is exposed on `.receipt`.
+   */
+  async waitForTransaction (hash, options = {}) {
+    const {
+      target = 'confirmed',
+      interval = this._defaultWaitInterval,
+      timeout = this._defaultWaitTimeout
+    } = options
+
+    const deadline = Date.now() + timeout
+    let last = null
+
+    while (true) {
+      const receipt = await this.getTransaction(hash)
+
+      if (receipt) {
+        last = receipt
+
+        if (receipt.finality === 'dropped') {
+          throw new TransactionDroppedError(hash, receipt)
+        }
+        if (receipt.success === false) {
+          throw new TransactionFailedError(hash, receipt)
+        }
+        if (this._meetsFinality(receipt.finality, target)) {
+          return receipt
+        }
+      }
+      // A null receipt (not seen yet) or a 'pending' finality means we keep polling.
+
+      if (Date.now() >= deadline) {
+        throw new TransactionConfirmationTimeoutError(hash, target, last)
+      }
+
+      await new Promise(resolve => setTimeout(resolve, interval))
+    }
+  }
+
+  /**
+   * Decides whether a finality level satisfies the requested target.
+   *
+   * @protected
+   * @param {Finality} finality - The observed finality level.
+   * @param {WaitForTransactionTarget} target - The requested finality target.
+   * @returns {boolean} True if the observed finality satisfies the target.
+   */
+  _meetsFinality (finality, target) {
+    if (target === 'final') {
+      return finality === 'final'
+    }
+
+    return finality === 'confirmed' || finality === 'final'
+  }
+
+  /**
+   * The default poll cadence for {@link waitForTransaction}, in milliseconds.
+   * Modules override this to match their block cadence.
+   *
+   * @protected
+   * @type {number}
+   */
+  get _defaultWaitInterval () {
+    return 4000
+  }
+
+  /**
+   * The default total time budget for {@link waitForTransaction}, in milliseconds.
+   * Modules override this to match their finality expectations.
+   *
+   * @protected
+   * @type {number}
+   */
+  get _defaultWaitTimeout () {
+    return 60000
   }
 }

--- a/src/wallet-account-read-only.js
+++ b/src/wallet-account-read-only.js
@@ -21,6 +21,10 @@ import {
 
 import { IWalletAccountReadOnlySimple } from './wallet-account-read-only-simple.js'
 
+/** @typedef {import('./wallet-account-read-only-simple.js').Finality} Finality */
+/** @typedef {import('./wallet-account-read-only-simple.js').TransactionReceipt} TransactionReceipt */
+/** @typedef {import('./wallet-account-read-only-simple.js').WaitForTransactionOptions} WaitForTransactionOptions */
+
 /**
  * @typedef {Object} Transaction
  * @property {string} to - The transaction's recipient.
@@ -47,17 +51,6 @@ import { IWalletAccountReadOnlySimple } from './wallet-account-read-only-simple.
  */
 
 /**
- * A normalized, cross-chain transaction finality level.
- *
- * - `pending`: seen, not settled (mempool / processed / in-flight).
- * - `confirmed`: settled, reversible only under extreme conditions.
- * - `final`: irreversible per the chain's own guarantees.
- * - `dropped`: evicted / replaced, never landed.
- *
- * @typedef {'pending' | 'confirmed' | 'final' | 'dropped'} Finality
- */
-
-/**
  * Enum that assigns a comparable ordinal to each finality level, used to check
  * whether an observed finality satisfies a requested target.
  *
@@ -72,31 +65,14 @@ export const FINALITY = {
 }
 
 /**
- * A normalized, cross-chain transaction receipt. Blockchain modules extend this
- * type with their own native receipt fields (e.g. `confirmations`, the raw
- * transaction and receipt objects, etc.).
+ * Resolves after the given number of milliseconds.
  *
- * @typedef {Object} TransactionReceipt
- * @property {string} hash - The transaction's identifier (hash / signature / lt:hash).
- * @property {Finality} finality - The transaction's finality level.
- * @property {boolean} [success] - The execution's result (not set if the transaction is still pending or it has been dropped).
- * @property {number} [block] - A reference to the including block (block number / height / slot / masterchain seqno).
- * @property {bigint} [fee] - The fee paid, when known.
+ * @param {number} amount - The delay, in milliseconds.
+ * @returns {Promise<void>} A promise that resolves once the delay elapses.
  */
-
-/**
- * The finality level to wait for.
- *
- * @typedef {'confirmed' | 'final'} WaitForTransactionTarget
- */
-
-/**
- * @typedef {Object} WaitForTransactionOptions
- * @property {WaitForTransactionTarget} [target] - The finality target to wait for (default: 'confirmed').
- * @property {number} [timeout] - The total time budget in milliseconds before giving up (default: 60000).
- * @property {number} [interval] - The poll cadence in milliseconds (default: 4000).
- * @property {number} [maxPollErrors] - How many consecutive getTransaction() failures to tolerate before rethrowing (default: 3).
- */
+async function sleep (amount) {
+  await new Promise(resolve => setTimeout(resolve, amount))
+}
 
 /** @interface */
 export class IWalletAccountReadOnly extends IWalletAccountReadOnlySimple {
@@ -118,41 +94,6 @@ export class IWalletAccountReadOnly extends IWalletAccountReadOnlySimple {
    */
   async quoteTransfer (options) {
     throw new NotImplementedError('quoteTransfer(options)')
-  }
-
-  /**
-   * Returns a transaction's receipt.
-   *
-   * @deprecated Use {@link getTransaction} instead, which returns a normalized, finality-based receipt. The native receipt fields remain available on each module's extended return type.
-   * @param {string} hash - The transaction's hash.
-   * @returns {Promise<unknown | null>} The receipt, or null if the transaction has not been included in a block yet.
-   */
-  async getTransactionReceipt (hash) {
-    throw new NotImplementedError('getTransactionReceipt(hash)')
-  }
-
-  /**
-   * Returns a normalized, finality-based receipt for a transaction.
-   *
-   * @param {string} hash - The transaction's identifier (hash / signature / lt:hash).
-   * @returns {Promise<TransactionReceipt>} The normalized receipt.
-   * @throws {ValueError} If the hash is not a valid identifier.
-   * @throws {NoSuchElementError} If no transaction has been found for the given hash.
-   */
-  async getTransaction (hash) {
-    throw new NotImplementedError('getTransaction(hash)')
-  }
-
-  /**
-   * Blocks until a transaction reaches a terminal state (the requested finality target or `dropped`), or times out.
-   *
-   * @param {string} hash - The transaction's identifier.
-   * @param {WaitForTransactionOptions} [options] - The wait options.
-   * @returns {Promise<TransactionReceipt>} The terminal receipt.
-   * @throws {TimeoutError} If the target is not reached before the timeout.
-   */
-  async waitForTransaction (hash, options) {
-    throw new NotImplementedError('waitForTransaction(hash, options)')
   }
 }
 
@@ -353,7 +294,7 @@ export default class WalletAccountReadOnly {
         throw new TimeoutError(`Transaction '${hash}' did not reach '${target}' within the timeout.`)
       }
 
-      await new Promise(resolve => setTimeout(resolve, interval))
+      await sleep(interval)
     }
   }
 }

--- a/src/wallet-account-read-only.js
+++ b/src/wallet-account-read-only.js
@@ -304,7 +304,7 @@ export default class WalletAccountReadOnly {
    * @param {WaitForTransactionOptions} [options] - The wait options.
    * @returns {Promise<TransactionReceipt>} The terminal receipt once the target is reached.
    * @throws {TransactionFailedError} If the transaction lands but reverts (success === false). The receipt is exposed on `.receipt`.
-   * @throws {TransactionDroppedError} If the transaction is evicted or replaced. The receipt is exposed on `.receipt`.
+   * @throws {TransactionDroppedError} If the transaction is reported dropped on two consecutive polls. The receipt is exposed on `.receipt`.
    * @throws {TransactionConfirmationTimeoutError} If the target is not reached before the timeout. The last-seen receipt (or null) is exposed on `.receipt`.
    */
   async waitForTransaction (hash, options = {}) {
@@ -316,6 +316,7 @@ export default class WalletAccountReadOnly {
 
     const deadline = Date.now() + timeout
     let last = null
+    let droppedStreak = 0
 
     while (true) {
       const receipt = await this.getTransaction(hash)
@@ -324,16 +325,22 @@ export default class WalletAccountReadOnly {
         last = receipt
 
         if (receipt.finality === 'dropped') {
-          throw new TransactionDroppedError(hash, receipt)
+          if (++droppedStreak >= 2) {
+            throw new TransactionDroppedError(hash, receipt)
+          }
+        } else {
+          droppedStreak = 0
+
+          if (receipt.success === false) {
+            throw new TransactionFailedError(hash, receipt)
+          }
+          if (this._meetsFinality(receipt.finality, target)) {
+            return receipt
+          }
         }
-        if (receipt.success === false) {
-          throw new TransactionFailedError(hash, receipt)
-        }
-        if (this._meetsFinality(receipt.finality, target)) {
-          return receipt
-        }
+      } else {
+        droppedStreak = 0
       }
-      // A null receipt (not seen yet) or a 'pending' finality means we keep polling.
 
       if (Date.now() >= deadline) {
         throw new TransactionConfirmationTimeoutError(hash, target, last)

--- a/src/wallet-account-read-only.js
+++ b/src/wallet-account-read-only.js
@@ -64,7 +64,7 @@ import {
  * @typedef {Object} TransactionReceipt
  * @property {string} id - The transaction's identifier (hash / signature / lt:hash).
  * @property {Finality} finality - The transaction's finality level.
- * @property {boolean | null} success - The execution result, or null while pending/dropped.
+ * @property {boolean} [success] - The execution's result (not set if the transaction is still pending or it has been dropped).
  * @property {string | number} [blockRef] - A reference to the including block (block hash / slot / masterchain seqno).
  * @property {bigint} [fee] - The fee paid, when known.
  */

--- a/src/wallet-account-read-only.js
+++ b/src/wallet-account-read-only.js
@@ -65,7 +65,7 @@ import {
  * @property {string} id - The transaction's identifier (hash / signature / lt:hash).
  * @property {Finality} finality - The transaction's finality level.
  * @property {boolean} [success] - The execution's result (not set if the transaction is still pending or it has been dropped).
- * @property {string | number} [blockRef] - A reference to the including block (block hash / slot / masterchain seqno).
+ * @property {string | number} [block] - A reference to the including block (block hash / slot / masterchain seqno).
  * @property {bigint} [fee] - The fee paid, when known.
  */
 

--- a/src/wallet-account-read-only.js
+++ b/src/wallet-account-read-only.js
@@ -300,14 +300,10 @@ export default class WalletAccountReadOnly {
    * The polling loop and target resolution are chain-agnostic: this method only
    * interprets the normalized receipt returned by {@link getTransaction}.
    *
-   * A reverted transaction still reaches its finality target, so it is returned
-   * like any other; callers dispatch on the receipt's `finality` and `success`
-   * fields to tell success, revert, and drop apart. Only a timeout throws.
-   *
    * @param {string} hash - The transaction's identifier.
    * @param {WaitForTransactionOptions} [options] - The wait options.
    * @returns {Promise<TransactionReceipt>} The terminal receipt: the finality target reached (inspect `success` to tell success from revert), or `dropped`.
-   * @throws {TimeoutError} If the target is not reached before the timeout. The last-seen receipt (or null) is exposed on `.receipt`.
+   * @throws {TimeoutError} If the target is not reached before the timeout.
    */
   async waitForTransaction (hash, options = {}) {
     const {
@@ -318,7 +314,6 @@ export default class WalletAccountReadOnly {
     } = options
 
     const deadline = Date.now() + timeout
-    let last = null
     let droppedStreak = 0
     let errorStreak = 0
 
@@ -335,18 +330,13 @@ export default class WalletAccountReadOnly {
       }
 
       if (receipt) {
-        last = receipt
-
         if (receipt.finality === 'dropped') {
-          // Debounce a transient drop; only treat it as terminal once it persists.
           if (++droppedStreak >= 2) {
             return receipt
           }
         } else {
           droppedStreak = 0
 
-          // A reverted transaction still reaches its finality target: it is
-          // returned like any other, and the caller inspects `success`.
           if (this._meetsFinality(receipt.finality, target)) {
             return receipt
           }
@@ -356,7 +346,7 @@ export default class WalletAccountReadOnly {
       }
 
       if (Date.now() >= deadline) {
-        throw new TimeoutError(hash, target, last)
+        throw new TimeoutError(`Transaction '${hash}' did not reach '${target}' within the timeout.`)
       }
 
       await new Promise(resolve => setTimeout(resolve, interval))

--- a/src/wallet-account-read-only.js
+++ b/src/wallet-account-read-only.js
@@ -15,6 +15,7 @@
 
 import {
   NotImplementedError,
+  NoSuchElementError,
   TimeoutError
 } from './errors.js'
 
@@ -134,7 +135,9 @@ export class IWalletAccountReadOnly extends IWalletAccountReadOnlySimple {
    * Returns a normalized, finality-based receipt for a transaction.
    *
    * @param {string} hash - The transaction's identifier (hash / signature / lt:hash).
-   * @returns {Promise<TransactionReceipt | null>} The normalized receipt, or null if the transaction is not known.
+   * @returns {Promise<TransactionReceipt>} The normalized receipt.
+   * @throws {ValueError} If the hash is not a valid identifier.
+   * @throws {NoSuchElementError} If no transaction has been found for the given hash.
    */
   async getTransaction (hash) {
     throw new NotImplementedError('getTransaction(hash)')
@@ -264,7 +267,9 @@ export default class WalletAccountReadOnly {
    *
    * @abstract
    * @param {string} hash - The transaction's identifier (hash / signature / lt:hash).
-   * @returns {Promise<TransactionReceipt | null>} The normalized receipt, or null if the transaction is not known.
+   * @returns {Promise<TransactionReceipt>} The normalized receipt.
+   * @throws {ValueError} If the hash is not a valid identifier.
+   * @throws {NoSuchElementError} If no transaction has been found for the given hash.
    */
   async getTransaction (hash) {
     throw new NotImplementedError('getTransaction(hash)')
@@ -275,7 +280,9 @@ export default class WalletAccountReadOnly {
    * target or `dropped`), or times out.
    *
    * The polling loop and target resolution are chain-agnostic: this method only
-   * interprets the normalized receipt returned by {@link getTransaction}.
+   * interprets the normalized receipt returned by {@link getTransaction}. A
+   * {@link NoSuchElementError} is treated as a transient not-found, so the loop
+   * keeps polling until the timeout.
    *
    * @param {string} hash - The transaction's identifier.
    * @param {WaitForTransactionOptions} [options] - The wait options.
@@ -301,7 +308,9 @@ export default class WalletAccountReadOnly {
         receipt = await this.getTransaction(hash)
         errorStreak = 0
       } catch (error) {
-        if (++errorStreak > maxPollErrors) {
+        if (error instanceof NoSuchElementError) {
+          errorStreak = 0
+        } else if (++errorStreak > maxPollErrors) {
           throw error
         }
       }

--- a/src/wallet-account-read-only.js
+++ b/src/wallet-account-read-only.js
@@ -370,16 +370,15 @@ export default class WalletAccountReadOnly {
     return finality === 'confirmed' || finality === 'final'
   }
 
-  /**
-   * The default poll cadence for {@link waitForTransaction}, in milliseconds.
-   * Modules override this to match their block cadence.
-   *
-   * @protected
-   * @type {number}
-   */
-  get _defaultWaitInterval () {
-    return 4000
-  }
+ /**
+  * The default poll cadence for {@link waitForTransaction}, in milliseconds.
+  *
+  * @protected
+  * @type {number}
+  */
+ get _defaultWaitInterval () {
+   return 4000
+ }
 
   /**
    * The default total time budget for {@link waitForTransaction}, in milliseconds.

--- a/src/wallet-account-read-only.js
+++ b/src/wallet-account-read-only.js
@@ -57,6 +57,20 @@ import { IWalletAccountReadOnlySimple } from './wallet-account-read-only-simple.
  */
 
 /**
+ * Enum that assigns a comparable ordinal to each finality level, used to check
+ * whether an observed finality satisfies a requested target.
+ *
+ * @readonly
+ * @enum {number}
+ */
+export const FINALITY = {
+  pending: 0,
+  dropped: 1,
+  confirmed: 2,
+  final: 3
+}
+
+/**
  * A normalized, cross-chain transaction receipt. Blockchain modules extend this
  * type with their own native receipt fields (e.g. `confirmations`, the raw
  * transaction and receipt objects, etc.).
@@ -300,7 +314,7 @@ export default class WalletAccountReadOnly {
         } else {
           droppedStreak = 0
 
-          if (this._meetsFinality(receipt.finality, target)) {
+          if (FINALITY[receipt.finality] >= FINALITY[target]) {
             return receipt
           }
         }
@@ -314,22 +328,6 @@ export default class WalletAccountReadOnly {
 
       await new Promise(resolve => setTimeout(resolve, interval))
     }
-  }
-
-  /**
-   * Decides whether a finality level satisfies the requested target.
-   *
-   * @protected
-   * @param {Finality} finality - The observed finality level.
-   * @param {WaitForTransactionTarget} target - The requested finality target.
-   * @returns {boolean} True if the observed finality satisfies the target.
-   */
-  _meetsFinality (finality, target) {
-    if (target === 'final') {
-      return finality === 'final'
-    }
-
-    return finality === 'confirmed' || finality === 'final'
   }
 
   /**

--- a/src/wallet-account-read-only.js
+++ b/src/wallet-account-read-only.js
@@ -103,22 +103,26 @@ export class IWalletAccountReadOnly extends IWalletAccountReadOnlySimple {
  */
 export default class WalletAccountReadOnly {
   /**
-   * The default poll cadence for {@link waitForTransaction}, in milliseconds.
-   * Subclasses may override this to match their finality expectations.
+   * The default poll cadence for {@link waitForTransaction}, in milliseconds,
+   * applied when the caller doesn't provide an `interval`. Subclasses override
+   * it to match their chain's block time.
    *
-   * @protected
    * @type {number}
    */
-  static _DEFAULT_WAIT_INTERVAL = 4000
+  get defaultWaitInterval () {
+    return 4000
+  }
 
   /**
-   * The default total time budget for {@link waitForTransaction}, in milliseconds.
-   * Subclasses may override this to match their finality expectations.
+   * The default time budget for {@link waitForTransaction}, in milliseconds,
+   * applied when the caller doesn't provide a `timeout`. Subclasses override it
+   * to match their chain's finality expectations.
    *
-   * @protected
    * @type {number}
    */
-  static _DEFAULT_WAIT_TIMEOUT = 60000
+  get defaultWaitTimeout () {
+    return 60000
+  }
 
   /**
    * Creates a new read-only wallet account.
@@ -251,8 +255,8 @@ export default class WalletAccountReadOnly {
   async waitForTransaction (hash, options = {}) {
     const {
       target = 'confirmed',
-      interval = this.constructor._DEFAULT_WAIT_INTERVAL,
-      timeout = this.constructor._DEFAULT_WAIT_TIMEOUT,
+      interval = this.defaultWaitInterval,
+      timeout = this.defaultWaitTimeout,
       maxPollErrors = 3
     } = options
 

--- a/src/wallet-account-read-only.js
+++ b/src/wallet-account-read-only.js
@@ -332,15 +332,15 @@ export default class WalletAccountReadOnly {
     return finality === 'confirmed' || finality === 'final'
   }
 
- /**
+  /**
   * The default poll cadence for {@link waitForTransaction}, in milliseconds.
   *
   * @protected
   * @type {number}
   */
- get _defaultWaitInterval () {
-   return 4000
- }
+  get _defaultWaitInterval () {
+    return 4000
+  }
 
   /**
    * The default total time budget for {@link waitForTransaction}, in milliseconds.

--- a/src/wallet-account-read-only.js
+++ b/src/wallet-account-read-only.js
@@ -65,7 +65,7 @@ import { IWalletAccountReadOnlySimple } from './wallet-account-read-only-simple.
  * @property {string} id - The transaction's identifier (hash / signature / lt:hash).
  * @property {Finality} finality - The transaction's finality level.
  * @property {boolean} [success] - The execution's result (not set if the transaction is still pending or it has been dropped).
- * @property {string | number} [block] - A reference to the including block (block hash / slot / masterchain seqno).
+ * @property {number} [block] - A reference to the including block (block number / height / slot / masterchain seqno).
  * @property {bigint} [fee] - The fee paid, when known.
  */
 

--- a/src/wallet-account-read-only.js
+++ b/src/wallet-account-read-only.js
@@ -165,11 +165,12 @@ export class IWalletAccountReadOnly {
   }
 
   /**
-   * Blocks until a transaction reaches the requested finality target, fails, is dropped, or times out.
+   * Blocks until a transaction reaches a terminal state (the requested finality target or `dropped`), or times out.
    *
    * @param {string} hash - The transaction's identifier.
    * @param {WaitForTransactionOptions} [options] - The wait options.
    * @returns {Promise<TransactionReceipt>} The terminal receipt.
+   * @throws {TimeoutError} If the target is not reached before the timeout.
    */
   async waitForTransaction (hash, options) {
     throw new NotImplementedError('waitForTransaction(hash, options)')

--- a/tests/wallet-account-read-only.test.js
+++ b/tests/wallet-account-read-only.test.js
@@ -3,6 +3,7 @@ import { describe, expect, test } from '@jest/globals'
 import {
   WalletAccountReadOnly,
   TimeoutError,
+  NoSuchElementError,
   FINALITY
 } from '../index.js'
 
@@ -42,6 +43,9 @@ class ScriptedWalletAccountReadOnly extends DummyWalletAccountReadOnly {
   async getTransaction (hash) {
     const item = this._sequence[Math.min(this.calls, this._sequence.length - 1)]
     this.calls += 1
+    if (item === null) {
+      throw new NoSuchElementError(`No transaction found for '${hash}'.`)
+    }
     return item
   }
 

--- a/tests/wallet-account-read-only.test.js
+++ b/tests/wallet-account-read-only.test.js
@@ -72,13 +72,6 @@ describe('WalletAccountReadOnly', () => {
     })
   })
 
-  describe('getTransaction', () => {
-    test('should throw NotImplementedError by default', async () => {
-      const account = new DummyWalletAccountReadOnly(ADDRESS)
-      await expect(account.getTransaction(HASH)).rejects.toThrow("Method 'getTransaction(hash)' must be implemented.")
-    })
-  })
-
   describe('_meetsFinality', () => {
     const account = new DummyWalletAccountReadOnly(ADDRESS)
 

--- a/tests/wallet-account-read-only.test.js
+++ b/tests/wallet-account-read-only.test.js
@@ -1,6 +1,11 @@
 import { describe, expect, test } from '@jest/globals'
 
-import { WalletAccountReadOnly } from '../index.js'
+import {
+  WalletAccountReadOnly,
+  TransactionFailedError,
+  TransactionDroppedError,
+  TransactionConfirmationTimeoutError
+} from '../index.js'
 
 class DummyWalletAccountReadOnly extends WalletAccountReadOnly {
   async getBalance () {
@@ -24,7 +29,34 @@ class DummyWalletAccountReadOnly extends WalletAccountReadOnly {
   }
 }
 
+/**
+ * A dummy account whose getTransaction returns a scripted sequence of receipts,
+ * so the shared waitForTransaction loop can be exercised deterministically.
+ */
+class ScriptedWalletAccountReadOnly extends DummyWalletAccountReadOnly {
+  constructor (sequence) {
+    super(ADDRESS)
+    this._sequence = sequence
+    this.calls = 0
+  }
+
+  async getTransaction (hash) {
+    const item = this._sequence[Math.min(this.calls, this._sequence.length - 1)]
+    this.calls += 1
+    return item
+  }
+
+  get _defaultWaitInterval () {
+    return 1
+  }
+
+  get _defaultWaitTimeout () {
+    return 50
+  }
+}
+
 const ADDRESS = '0xa460AEbce0d3A4BecAd8ccf9D6D4861296c503Bd'
+const HASH = '0xabc'
 
 describe('WalletAccountReadOnly', () => {
   describe('getAddress', () => {
@@ -39,6 +71,94 @@ describe('WalletAccountReadOnly', () => {
 
       await expect(account.getAddress())
         .rejects.toThrow("The account's address must be set to perform this operation.")
+    })
+  })
+
+  describe('getTransaction', () => {
+    test('should throw NotImplementedError by default', async () => {
+      const account = new DummyWalletAccountReadOnly(ADDRESS)
+      await expect(account.getTransaction(HASH)).rejects.toThrow("Method 'getTransaction(hash)' must be implemented.")
+    })
+  })
+
+  describe('_meetsFinality', () => {
+    const account = new DummyWalletAccountReadOnly(ADDRESS)
+
+    test("target 'confirmed' is met by confirmed and final", () => {
+      expect(account._meetsFinality('confirmed', 'confirmed')).toBe(true)
+      expect(account._meetsFinality('final', 'confirmed')).toBe(true)
+      expect(account._meetsFinality('pending', 'confirmed')).toBe(false)
+    })
+
+    test("target 'final' is met only by final", () => {
+      expect(account._meetsFinality('final', 'final')).toBe(true)
+      expect(account._meetsFinality('confirmed', 'final')).toBe(false)
+      expect(account._meetsFinality('pending', 'final')).toBe(false)
+    })
+  })
+
+  describe('waitForTransaction', () => {
+    test('resolves once the confirmed target is reached', async () => {
+      const confirmed = { id: HASH, finality: 'confirmed', success: true }
+      const account = new ScriptedWalletAccountReadOnly([
+        null,
+        { id: HASH, finality: 'pending', success: null },
+        confirmed
+      ])
+
+      const receipt = await account.waitForTransaction(HASH)
+      expect(receipt).toBe(confirmed)
+      expect(account.calls).toBe(3)
+    })
+
+    test("keeps polling past 'confirmed' when target is 'final'", async () => {
+      const final = { id: HASH, finality: 'final', success: true }
+      const account = new ScriptedWalletAccountReadOnly([
+        { id: HASH, finality: 'confirmed', success: true },
+        final
+      ])
+
+      const receipt = await account.waitForTransaction(HASH, { target: 'final' })
+      expect(receipt).toBe(final)
+    })
+
+    test('throws TransactionFailedError with the receipt on revert', async () => {
+      const failed = { id: HASH, finality: 'final', success: false }
+      const account = new ScriptedWalletAccountReadOnly([failed])
+
+      await expect(account.waitForTransaction(HASH)).rejects.toThrow(TransactionFailedError)
+      await account.waitForTransaction(HASH).catch(err => {
+        expect(err.receipt).toBe(failed)
+      })
+    })
+
+    test('throws TransactionDroppedError with the receipt when dropped', async () => {
+      const dropped = { id: HASH, finality: 'dropped', success: null }
+      const account = new ScriptedWalletAccountReadOnly([dropped])
+
+      await expect(account.waitForTransaction(HASH)).rejects.toThrow(TransactionDroppedError)
+      await account.waitForTransaction(HASH).catch(err => {
+        expect(err.receipt).toBe(dropped)
+      })
+    })
+
+    test('throws TransactionConfirmationTimeoutError carrying the last-seen receipt', async () => {
+      const pending = { id: HASH, finality: 'pending', success: null }
+      const account = new ScriptedWalletAccountReadOnly([pending])
+
+      await account.waitForTransaction(HASH, { timeout: 10, interval: 1 }).catch(err => {
+        expect(err).toBeInstanceOf(TransactionConfirmationTimeoutError)
+        expect(err.receipt).toBe(pending)
+      })
+    })
+
+    test('timeout receipt is null when the tx was never seen', async () => {
+      const account = new ScriptedWalletAccountReadOnly([null])
+
+      await account.waitForTransaction(HASH, { timeout: 10, interval: 1 }).catch(err => {
+        expect(err).toBeInstanceOf(TransactionConfirmationTimeoutError)
+        expect(err.receipt).toBeNull()
+      })
     })
   })
 })

--- a/tests/wallet-account-read-only.test.js
+++ b/tests/wallet-account-read-only.test.js
@@ -49,13 +49,8 @@ class ScriptedWalletAccountReadOnly extends DummyWalletAccountReadOnly {
     return item
   }
 
-  get _defaultWaitInterval () {
-    return 1
-  }
-
-  get _defaultWaitTimeout () {
-    return 50
-  }
+  static _DEFAULT_WAIT_INTERVAL = 1
+  static _DEFAULT_WAIT_TIMEOUT = 50
 }
 
 const ADDRESS = '0xa460AEbce0d3A4BecAd8ccf9D6D4861296c503Bd'

--- a/tests/wallet-account-read-only.test.js
+++ b/tests/wallet-account-read-only.test.js
@@ -132,7 +132,7 @@ describe('WalletAccountReadOnly', () => {
       })
     })
 
-    test('throws TransactionDroppedError with the receipt when dropped', async () => {
+    test('throws TransactionDroppedError with the receipt when dropped on consecutive polls', async () => {
       const dropped = { id: HASH, finality: 'dropped', success: null }
       const account = new ScriptedWalletAccountReadOnly([dropped])
 
@@ -140,6 +140,18 @@ describe('WalletAccountReadOnly', () => {
       await account.waitForTransaction(HASH).catch(err => {
         expect(err.receipt).toBe(dropped)
       })
+    })
+
+    test('debounces a transient drop that recovers to confirmed', async () => {
+      const confirmed = { id: HASH, finality: 'confirmed', success: true }
+      const account = new ScriptedWalletAccountReadOnly([
+        { id: HASH, finality: 'dropped', success: null },
+        confirmed
+      ])
+
+      const receipt = await account.waitForTransaction(HASH)
+      expect(receipt).toBe(confirmed)
+      expect(account.calls).toBe(2)
     })
 
     test('throws TransactionConfirmationTimeoutError carrying the last-seen receipt', async () => {

--- a/tests/wallet-account-read-only.test.js
+++ b/tests/wallet-account-read-only.test.js
@@ -2,9 +2,7 @@ import { describe, expect, test } from '@jest/globals'
 
 import {
   WalletAccountReadOnly,
-  TransactionFailedError,
-  TransactionDroppedError,
-  TransactionConfirmationTimeoutError
+  TimeoutError
 } from '../index.js'
 
 class DummyWalletAccountReadOnly extends WalletAccountReadOnly {
@@ -122,24 +120,20 @@ describe('WalletAccountReadOnly', () => {
       expect(receipt).toBe(final)
     })
 
-    test('throws TransactionFailedError with the receipt on revert', async () => {
+    test('returns the receipt when the transaction reverts, without throwing', async () => {
       const failed = { id: HASH, finality: 'final', success: false }
       const account = new ScriptedWalletAccountReadOnly([failed])
 
-      await expect(account.waitForTransaction(HASH)).rejects.toThrow(TransactionFailedError)
-      await account.waitForTransaction(HASH).catch(err => {
-        expect(err.receipt).toBe(failed)
-      })
+      const receipt = await account.waitForTransaction(HASH)
+      expect(receipt).toBe(failed)
     })
 
-    test('throws TransactionDroppedError with the receipt when dropped on consecutive polls', async () => {
+    test('returns the receipt when the transaction is dropped on consecutive polls', async () => {
       const dropped = { id: HASH, finality: 'dropped', success: undefined }
       const account = new ScriptedWalletAccountReadOnly([dropped])
 
-      await expect(account.waitForTransaction(HASH)).rejects.toThrow(TransactionDroppedError)
-      await account.waitForTransaction(HASH).catch(err => {
-        expect(err.receipt).toBe(dropped)
-      })
+      const receipt = await account.waitForTransaction(HASH)
+      expect(receipt).toBe(dropped)
     })
 
     test('debounces a transient drop that recovers to confirmed', async () => {
@@ -154,12 +148,12 @@ describe('WalletAccountReadOnly', () => {
       expect(account.calls).toBe(2)
     })
 
-    test('throws TransactionConfirmationTimeoutError carrying the last-seen receipt', async () => {
+    test('throws TimeoutError carrying the last-seen receipt', async () => {
       const pending = { id: HASH, finality: 'pending', success: undefined }
       const account = new ScriptedWalletAccountReadOnly([pending])
 
       await account.waitForTransaction(HASH, { timeout: 10, interval: 1 }).catch(err => {
-        expect(err).toBeInstanceOf(TransactionConfirmationTimeoutError)
+        expect(err).toBeInstanceOf(TimeoutError)
         expect(err.receipt).toBe(pending)
       })
     })
@@ -168,7 +162,7 @@ describe('WalletAccountReadOnly', () => {
       const account = new ScriptedWalletAccountReadOnly([null])
 
       await account.waitForTransaction(HASH, { timeout: 10, interval: 1 }).catch(err => {
-        expect(err).toBeInstanceOf(TransactionConfirmationTimeoutError)
+        expect(err).toBeInstanceOf(TimeoutError)
         expect(err.receipt).toBeNull()
       })
     })

--- a/tests/wallet-account-read-only.test.js
+++ b/tests/wallet-account-read-only.test.js
@@ -2,7 +2,8 @@ import { describe, expect, test } from '@jest/globals'
 
 import {
   WalletAccountReadOnly,
-  TimeoutError
+  TimeoutError,
+  FINALITY
 } from '../index.js'
 
 class DummyWalletAccountReadOnly extends WalletAccountReadOnly {
@@ -72,19 +73,10 @@ describe('WalletAccountReadOnly', () => {
     })
   })
 
-  describe('_meetsFinality', () => {
-    const account = new DummyWalletAccountReadOnly(ADDRESS)
-
-    test("target 'confirmed' is met by confirmed and final", () => {
-      expect(account._meetsFinality('confirmed', 'confirmed')).toBe(true)
-      expect(account._meetsFinality('final', 'confirmed')).toBe(true)
-      expect(account._meetsFinality('pending', 'confirmed')).toBe(false)
-    })
-
-    test("target 'final' is met only by final", () => {
-      expect(account._meetsFinality('final', 'final')).toBe(true)
-      expect(account._meetsFinality('confirmed', 'final')).toBe(false)
-      expect(account._meetsFinality('pending', 'final')).toBe(false)
+  describe('FINALITY', () => {
+    test('orders finalities so stronger settlement compares higher', () => {
+      expect(FINALITY.pending).toBeLessThan(FINALITY.confirmed)
+      expect(FINALITY.confirmed).toBeLessThan(FINALITY.final)
     })
   })
 

--- a/tests/wallet-account-read-only.test.js
+++ b/tests/wallet-account-read-only.test.js
@@ -90,10 +90,10 @@ describe('WalletAccountReadOnly', () => {
 
   describe('waitForTransaction', () => {
     test('resolves once the confirmed target is reached', async () => {
-      const confirmed = { id: HASH, finality: 'confirmed', success: true }
+      const confirmed = { hash: HASH, finality: 'confirmed', success: true }
       const account = new ScriptedWalletAccountReadOnly([
         null,
-        { id: HASH, finality: 'pending', success: undefined },
+        { hash: HASH, finality: 'pending', success: undefined },
         confirmed
       ])
 
@@ -103,9 +103,9 @@ describe('WalletAccountReadOnly', () => {
     })
 
     test("keeps polling past 'confirmed' when target is 'final'", async () => {
-      const final = { id: HASH, finality: 'final', success: true }
+      const final = { hash: HASH, finality: 'final', success: true }
       const account = new ScriptedWalletAccountReadOnly([
-        { id: HASH, finality: 'confirmed', success: true },
+        { hash: HASH, finality: 'confirmed', success: true },
         final
       ])
 
@@ -114,7 +114,7 @@ describe('WalletAccountReadOnly', () => {
     })
 
     test('returns the receipt when the transaction reverts, without throwing', async () => {
-      const failed = { id: HASH, finality: 'final', success: false }
+      const failed = { hash: HASH, finality: 'final', success: false }
       const account = new ScriptedWalletAccountReadOnly([failed])
 
       const receipt = await account.waitForTransaction(HASH)
@@ -122,7 +122,7 @@ describe('WalletAccountReadOnly', () => {
     })
 
     test('returns the receipt when the transaction is dropped on consecutive polls', async () => {
-      const dropped = { id: HASH, finality: 'dropped', success: undefined }
+      const dropped = { hash: HASH, finality: 'dropped', success: undefined }
       const account = new ScriptedWalletAccountReadOnly([dropped])
 
       const receipt = await account.waitForTransaction(HASH)
@@ -130,9 +130,9 @@ describe('WalletAccountReadOnly', () => {
     })
 
     test('debounces a transient drop that recovers to confirmed', async () => {
-      const confirmed = { id: HASH, finality: 'confirmed', success: true }
+      const confirmed = { hash: HASH, finality: 'confirmed', success: true }
       const account = new ScriptedWalletAccountReadOnly([
-        { id: HASH, finality: 'dropped', success: undefined },
+        { hash: HASH, finality: 'dropped', success: undefined },
         confirmed
       ])
 
@@ -142,7 +142,7 @@ describe('WalletAccountReadOnly', () => {
     })
 
     test('throws TimeoutError when the target is not reached in time', async () => {
-      const pending = { id: HASH, finality: 'pending', success: undefined }
+      const pending = { hash: HASH, finality: 'pending', success: undefined }
       const account = new ScriptedWalletAccountReadOnly([pending])
 
       await expect(account.waitForTransaction(HASH, { timeout: 10, interval: 1 }))

--- a/tests/wallet-account-read-only.test.js
+++ b/tests/wallet-account-read-only.test.js
@@ -148,23 +148,19 @@ describe('WalletAccountReadOnly', () => {
       expect(account.calls).toBe(2)
     })
 
-    test('throws TimeoutError carrying the last-seen receipt', async () => {
+    test('throws TimeoutError when the target is not reached in time', async () => {
       const pending = { id: HASH, finality: 'pending', success: undefined }
       const account = new ScriptedWalletAccountReadOnly([pending])
 
-      await account.waitForTransaction(HASH, { timeout: 10, interval: 1 }).catch(err => {
-        expect(err).toBeInstanceOf(TimeoutError)
-        expect(err.receipt).toBe(pending)
-      })
+      await expect(account.waitForTransaction(HASH, { timeout: 10, interval: 1 }))
+        .rejects.toThrow(TimeoutError)
     })
 
-    test('timeout receipt is null when the tx was never seen', async () => {
+    test('throws TimeoutError when the transaction is never seen', async () => {
       const account = new ScriptedWalletAccountReadOnly([null])
 
-      await account.waitForTransaction(HASH, { timeout: 10, interval: 1 }).catch(err => {
-        expect(err).toBeInstanceOf(TimeoutError)
-        expect(err.receipt).toBeNull()
-      })
+      await expect(account.waitForTransaction(HASH, { timeout: 10, interval: 1 }))
+        .rejects.toThrow(TimeoutError)
     })
   })
 })

--- a/tests/wallet-account-read-only.test.js
+++ b/tests/wallet-account-read-only.test.js
@@ -49,8 +49,13 @@ class ScriptedWalletAccountReadOnly extends DummyWalletAccountReadOnly {
     return item
   }
 
-  static _DEFAULT_WAIT_INTERVAL = 1
-  static _DEFAULT_WAIT_TIMEOUT = 50
+  get defaultWaitInterval () {
+    return 1
+  }
+
+  get defaultWaitTimeout () {
+    return 50
+  }
 }
 
 const ADDRESS = '0xa460AEbce0d3A4BecAd8ccf9D6D4861296c503Bd'

--- a/tests/wallet-account-read-only.test.js
+++ b/tests/wallet-account-read-only.test.js
@@ -102,7 +102,7 @@ describe('WalletAccountReadOnly', () => {
       const confirmed = { id: HASH, finality: 'confirmed', success: true }
       const account = new ScriptedWalletAccountReadOnly([
         null,
-        { id: HASH, finality: 'pending', success: null },
+        { id: HASH, finality: 'pending', success: undefined },
         confirmed
       ])
 
@@ -133,7 +133,7 @@ describe('WalletAccountReadOnly', () => {
     })
 
     test('throws TransactionDroppedError with the receipt when dropped on consecutive polls', async () => {
-      const dropped = { id: HASH, finality: 'dropped', success: null }
+      const dropped = { id: HASH, finality: 'dropped', success: undefined }
       const account = new ScriptedWalletAccountReadOnly([dropped])
 
       await expect(account.waitForTransaction(HASH)).rejects.toThrow(TransactionDroppedError)
@@ -145,7 +145,7 @@ describe('WalletAccountReadOnly', () => {
     test('debounces a transient drop that recovers to confirmed', async () => {
       const confirmed = { id: HASH, finality: 'confirmed', success: true }
       const account = new ScriptedWalletAccountReadOnly([
-        { id: HASH, finality: 'dropped', success: null },
+        { id: HASH, finality: 'dropped', success: undefined },
         confirmed
       ])
 
@@ -155,7 +155,7 @@ describe('WalletAccountReadOnly', () => {
     })
 
     test('throws TransactionConfirmationTimeoutError carrying the last-seen receipt', async () => {
-      const pending = { id: HASH, finality: 'pending', success: null }
+      const pending = { id: HASH, finality: 'pending', success: undefined }
       const account = new ScriptedWalletAccountReadOnly([pending])
 
       await account.waitForTransaction(HASH, { timeout: 10, interval: 1 }).catch(err => {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -12,5 +12,5 @@ export type TransactionReceipt = import("./src/wallet-account-read-only.js").Tra
 export type WaitForTransactionTarget = import("./src/wallet-account-read-only.js").WaitForTransactionTarget;
 export type WaitForTransactionOptions = import("./src/wallet-account-read-only.js").WaitForTransactionOptions;
 export type KeyPair = import("./src/wallet-account.js").KeyPair;
-export { default as WalletAccountReadOnly, IWalletAccountReadOnly } from "./src/wallet-account-read-only.js";
+export { default as WalletAccountReadOnly, IWalletAccountReadOnly, FINALITY } from "./src/wallet-account-read-only.js";
 export { NotImplementedError, SignerError, UnsupportedOperationError, ValueError, NoSuchElementError, TimeoutError } from "./src/errors.js";

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -7,6 +7,10 @@ export type Transaction = import("./src/wallet-account-read-only.js").Transactio
 export type TransactionResult = import("./src/wallet-account-read-only.js").TransactionResult;
 export type TransferOptions = import("./src/wallet-account-read-only.js").TransferOptions;
 export type TransferResult = import("./src/wallet-account-read-only.js").TransferResult;
+export type Finality = import("./src/wallet-account-read-only.js").Finality;
+export type TransactionReceipt = import("./src/wallet-account-read-only.js").TransactionReceipt;
+export type WaitForTransactionTarget = import("./src/wallet-account-read-only.js").WaitForTransactionTarget;
+export type WaitForTransactionOptions = import("./src/wallet-account-read-only.js").WaitForTransactionOptions;
 export type KeyPair = import("./src/wallet-account.js").KeyPair;
 export { default as WalletAccountReadOnly, IWalletAccountReadOnly } from "./src/wallet-account-read-only.js";
-export { NotImplementedError, SignerError, UnsupportedOperationError, ValueError, NoSuchElementError } from "./src/errors.js";
+export { NotImplementedError, SignerError, UnsupportedOperationError, ValueError, NoSuchElementError, TransactionFailedError, TransactionDroppedError, TransactionConfirmationTimeoutError } from "./src/errors.js";

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -7,10 +7,10 @@ export type Transaction = import("./src/wallet-account-read-only.js").Transactio
 export type TransactionResult = import("./src/wallet-account-read-only.js").TransactionResult;
 export type TransferOptions = import("./src/wallet-account-read-only.js").TransferOptions;
 export type TransferResult = import("./src/wallet-account-read-only.js").TransferResult;
-export type Finality = import("./src/wallet-account-read-only.js").Finality;
-export type TransactionReceipt = import("./src/wallet-account-read-only.js").TransactionReceipt;
-export type WaitForTransactionTarget = import("./src/wallet-account-read-only.js").WaitForTransactionTarget;
-export type WaitForTransactionOptions = import("./src/wallet-account-read-only.js").WaitForTransactionOptions;
+export type Finality = import("./src/wallet-account-read-only-simple.js").Finality;
+export type TransactionReceipt = import("./src/wallet-account-read-only-simple.js").TransactionReceipt;
+export type WaitForTransactionTarget = import("./src/wallet-account-read-only-simple.js").WaitForTransactionTarget;
+export type WaitForTransactionOptions = import("./src/wallet-account-read-only-simple.js").WaitForTransactionOptions;
 export type KeyPair = import("./src/wallet-account.js").KeyPair;
 export { default as WalletAccountReadOnly, IWalletAccountReadOnly, FINALITY } from "./src/wallet-account-read-only.js";
 export { NotImplementedError, SignerError, UnsupportedOperationError, ValueError, NoSuchElementError, TimeoutError } from "./src/errors.js";

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -13,4 +13,4 @@ export type WaitForTransactionTarget = import("./src/wallet-account-read-only.js
 export type WaitForTransactionOptions = import("./src/wallet-account-read-only.js").WaitForTransactionOptions;
 export type KeyPair = import("./src/wallet-account.js").KeyPair;
 export { default as WalletAccountReadOnly, IWalletAccountReadOnly } from "./src/wallet-account-read-only.js";
-export { NotImplementedError, SignerError, UnsupportedOperationError, ValueError, NoSuchElementError, TransactionFailedError, TransactionDroppedError, TransactionConfirmationTimeoutError } from "./src/errors.js";
+export { NotImplementedError, SignerError, UnsupportedOperationError, ValueError, NoSuchElementError, TimeoutError } from "./src/errors.js";

--- a/types/src/errors.d.ts
+++ b/types/src/errors.d.ts
@@ -42,14 +42,10 @@ export class NoSuchElementError extends Error {
 }
 export class TimeoutError extends Error {
     /**
-     * Create a new timeout error. Thrown when a transaction does not reach the
-     * requested finality target within the timeout.
+     * Create a new timeout error. Thrown when an operation does not complete
+     * within its allotted time.
      *
-     * @param {string} hash - The transaction's hash.
-     * @param {string} target - The requested finality target.
-     * @param {import('./wallet-account-read-only.js').TransactionReceipt | null} [receipt] - The last-seen receipt, or null if never seen.
+     * @param {string} message - The error's message.
      */
-    constructor(hash: string, target: string, receipt?: import("./wallet-account-read-only.js").TransactionReceipt | null);
-    /** @type {import('./wallet-account-read-only.js').TransactionReceipt | null} */
-    receipt: import("./wallet-account-read-only.js").TransactionReceipt | null;
+    constructor(message: string);
 }

--- a/types/src/errors.d.ts
+++ b/types/src/errors.d.ts
@@ -40,3 +40,40 @@ export class NoSuchElementError extends Error {
      */
     constructor(message: string);
 }
+export class TransactionFailedError extends Error {
+    /**
+     * Create a new transaction failed error. Thrown when a transaction lands on
+     * chain but its execution reverts.
+     *
+     * @param {string} hash - The transaction's hash.
+     * @param {import('./wallet-account-read-only.js').TransactionReceipt} [receipt] - The failed transaction's receipt.
+     */
+    constructor(hash: string, receipt?: import("./wallet-account-read-only.js").TransactionReceipt);
+    /** @type {import('./wallet-account-read-only.js').TransactionReceipt | undefined} */
+    receipt: import("./wallet-account-read-only.js").TransactionReceipt | undefined;
+}
+export class TransactionDroppedError extends Error {
+    /**
+     * Create a new transaction dropped error. Thrown when a transaction is evicted
+     * or replaced and never lands on chain.
+     *
+     * @param {string} hash - The transaction's hash.
+     * @param {import('./wallet-account-read-only.js').TransactionReceipt} [receipt] - The dropped transaction's receipt.
+     */
+    constructor(hash: string, receipt?: import("./wallet-account-read-only.js").TransactionReceipt);
+    /** @type {import('./wallet-account-read-only.js').TransactionReceipt | undefined} */
+    receipt: import("./wallet-account-read-only.js").TransactionReceipt | undefined;
+}
+export class TransactionConfirmationTimeoutError extends Error {
+    /**
+     * Create a new transaction confirmation timeout error. Thrown when a
+     * transaction does not reach the requested finality target within the timeout.
+     *
+     * @param {string} hash - The transaction's hash.
+     * @param {string} target - The requested finality target.
+     * @param {import('./wallet-account-read-only.js').TransactionReceipt | null} [receipt] - The last-seen receipt, or null if never seen.
+     */
+    constructor(hash: string, target: string, receipt?: import("./wallet-account-read-only.js").TransactionReceipt | null);
+    /** @type {import('./wallet-account-read-only.js').TransactionReceipt | null} */
+    receipt: import("./wallet-account-read-only.js").TransactionReceipt | null;
+}

--- a/types/src/errors.d.ts
+++ b/types/src/errors.d.ts
@@ -40,34 +40,10 @@ export class NoSuchElementError extends Error {
      */
     constructor(message: string);
 }
-export class TransactionFailedError extends Error {
+export class TimeoutError extends Error {
     /**
-     * Create a new transaction failed error. Thrown when a transaction lands on
-     * chain but its execution reverts.
-     *
-     * @param {string} hash - The transaction's hash.
-     * @param {import('./wallet-account-read-only.js').TransactionReceipt} [receipt] - The failed transaction's receipt.
-     */
-    constructor(hash: string, receipt?: import("./wallet-account-read-only.js").TransactionReceipt);
-    /** @type {import('./wallet-account-read-only.js').TransactionReceipt | undefined} */
-    receipt: import("./wallet-account-read-only.js").TransactionReceipt | undefined;
-}
-export class TransactionDroppedError extends Error {
-    /**
-     * Create a new transaction dropped error. Thrown when a transaction is evicted
-     * or replaced and never lands on chain.
-     *
-     * @param {string} hash - The transaction's hash.
-     * @param {import('./wallet-account-read-only.js').TransactionReceipt} [receipt] - The dropped transaction's receipt.
-     */
-    constructor(hash: string, receipt?: import("./wallet-account-read-only.js").TransactionReceipt);
-    /** @type {import('./wallet-account-read-only.js').TransactionReceipt | undefined} */
-    receipt: import("./wallet-account-read-only.js").TransactionReceipt | undefined;
-}
-export class TransactionConfirmationTimeoutError extends Error {
-    /**
-     * Create a new transaction confirmation timeout error. Thrown when a
-     * transaction does not reach the requested finality target within the timeout.
+     * Create a new timeout error. Thrown when a transaction does not reach the
+     * requested finality target within the timeout.
      *
      * @param {string} hash - The transaction's hash.
      * @param {string} target - The requested finality target.

--- a/types/src/wallet-account-read-only-simple.d.ts
+++ b/types/src/wallet-account-read-only-simple.d.ts
@@ -1,4 +1,62 @@
 /**
+ * A normalized, cross-chain transaction finality level.
+ *
+ * - `pending`: seen, not settled (mempool / processed / in-flight).
+ * - `confirmed`: settled, reversible only under extreme conditions.
+ * - `final`: irreversible per the chain's own guarantees.
+ * - `dropped`: evicted / replaced, never landed.
+ */
+export type Finality = "pending" | "confirmed" | "final" | "dropped";
+/**
+ * A normalized, cross-chain transaction receipt. Blockchain modules extend this
+ * type with their own native receipt fields (e.g. `confirmations`, the raw
+ * transaction and receipt objects, etc.).
+ */
+export type TransactionReceipt = {
+    /**
+     * - The transaction's identifier (hash / signature / lt:hash).
+     */
+    hash: string;
+    /**
+     * - The transaction's finality level.
+     */
+    finality: Finality;
+    /**
+     * - The execution's result (not set if the transaction is still pending or it has been dropped).
+     */
+    success?: boolean;
+    /**
+     * - A reference to the including block (block number / height / slot / masterchain seqno).
+     */
+    block?: number;
+    /**
+     * - The fee paid, when known.
+     */
+    fee?: bigint;
+};
+/**
+ * The finality level to wait for.
+ */
+export type WaitForTransactionTarget = "confirmed" | "final";
+export type WaitForTransactionOptions = {
+    /**
+     * - The finality target to wait for (default: 'confirmed').
+     */
+    target?: WaitForTransactionTarget;
+    /**
+     * - The total time budget in milliseconds before giving up (default: 60000).
+     */
+    timeout?: number;
+    /**
+     * - The poll cadence in milliseconds (default: 4000).
+     */
+    interval?: number;
+    /**
+     * - How many consecutive getTransaction() failures to tolerate before rethrowing (default: 3).
+     */
+    maxPollErrors?: number;
+};
+/**
  * The read-only members shared by every wallet account, single-signer or multisig.
  *
  * This is an internal base interface: it is not exported from the package entry point.
@@ -39,8 +97,27 @@ export interface IWalletAccountReadOnlySimple {
     /**
      * Returns a transaction's receipt.
      *
+     * @deprecated Use {@link getTransaction} instead, which returns a normalized, finality-based receipt. The native receipt fields remain available on each module's extended return type.
      * @param {string} hash - The transaction's hash.
      * @returns {Promise<unknown | null>} The receipt, or null if the transaction has not been included in a block yet.
      */
     getTransactionReceipt(hash: string): Promise<unknown | null>;
+    /**
+     * Returns a normalized, finality-based receipt for a transaction.
+     *
+     * @param {string} hash - The transaction's identifier (hash / signature / lt:hash).
+     * @returns {Promise<TransactionReceipt>} The normalized receipt.
+     * @throws {ValueError} If the hash is not a valid identifier.
+     * @throws {NoSuchElementError} If no transaction has been found for the given hash.
+     */
+    getTransaction(hash: string): Promise<TransactionReceipt>;
+    /**
+     * Blocks until a transaction reaches a terminal state (the requested finality target or `dropped`), or times out.
+     *
+     * @param {string} hash - The transaction's identifier.
+     * @param {WaitForTransactionOptions} [options] - The wait options.
+     * @returns {Promise<TransactionReceipt>} The terminal receipt.
+     * @throws {TimeoutError} If the target is not reached before the timeout.
+     */
+    waitForTransaction(hash: string, options?: WaitForTransactionOptions): Promise<TransactionReceipt>;
 }

--- a/types/src/wallet-account-read-only-simple.d.ts
+++ b/types/src/wallet-account-read-only-simple.d.ts
@@ -44,11 +44,11 @@ export type WaitForTransactionOptions = {
      */
     target?: WaitForTransactionTarget;
     /**
-     * - The total time budget in milliseconds before giving up (default: 60000).
+     * - The total time budget in milliseconds before giving up. If omitted, the account's `defaultWaitTimeout` is used.
      */
     timeout?: number;
     /**
-     * - The poll cadence in milliseconds (default: 4000).
+     * - The poll cadence in milliseconds. If omitted, the account's `defaultWaitInterval` is used.
      */
     interval?: number;
     /**

--- a/types/src/wallet-account-read-only.d.ts
+++ b/types/src/wallet-account-read-only.d.ts
@@ -157,7 +157,7 @@ export default abstract class WalletAccountReadOnly implements IWalletAccountRea
      * @param {WaitForTransactionOptions} [options] - The wait options.
      * @returns {Promise<TransactionReceipt>} The terminal receipt once the target is reached.
      * @throws {TransactionFailedError} If the transaction lands but reverts (success === false). The receipt is exposed on `.receipt`.
-     * @throws {TransactionDroppedError} If the transaction is evicted or replaced. The receipt is exposed on `.receipt`.
+     * @throws {TransactionDroppedError} If the transaction is reported dropped on two consecutive polls. The receipt is exposed on `.receipt`.
      * @throws {TransactionConfirmationTimeoutError} If the target is not reached before the timeout. The last-seen receipt (or null) is exposed on `.receipt`.
      */
     waitForTransaction(hash: string, options?: WaitForTransactionOptions): Promise<TransactionReceipt>;

--- a/types/src/wallet-account-read-only.d.ts
+++ b/types/src/wallet-account-read-only.d.ts
@@ -31,27 +31,27 @@ export interface IWalletAccountReadOnly extends IWalletAccountReadOnlySimple {
  */
 export default abstract class WalletAccountReadOnly implements IWalletAccountReadOnly {
     /**
-     * The default poll cadence for {@link waitForTransaction}, in milliseconds.
-     * Subclasses may override this to match their finality expectations.
-     *
-     * @protected
-     * @type {number}
-     */
-    protected static _DEFAULT_WAIT_INTERVAL: number;
-    /**
-     * The default total time budget for {@link waitForTransaction}, in milliseconds.
-     * Subclasses may override this to match their finality expectations.
-     *
-     * @protected
-     * @type {number}
-     */
-    protected static _DEFAULT_WAIT_TIMEOUT: number;
-    /**
      * Creates a new read-only wallet account.
      *
      * @param {string} [address] - The account's address.
      */
     constructor(address?: string);
+    /**
+     * The default poll cadence for {@link waitForTransaction}, in milliseconds,
+     * applied when the caller doesn't provide an `interval`. Subclasses override
+     * it to match their chain's block time.
+     *
+     * @type {number}
+     */
+    get defaultWaitInterval(): number;
+    /**
+     * The default time budget for {@link waitForTransaction}, in milliseconds,
+     * applied when the caller doesn't provide a `timeout`. Subclasses override it
+     * to match their chain's finality expectations.
+     *
+     * @type {number}
+     */
+    get defaultWaitTimeout(): number;
     /** @private */
     private __address;
     /**

--- a/types/src/wallet-account-read-only.d.ts
+++ b/types/src/wallet-account-read-only.d.ts
@@ -24,38 +24,28 @@ export interface IWalletAccountReadOnly extends IWalletAccountReadOnlySimple {
      * @returns {Promise<Omit<TransferResult, 'hash'>>} The transfer's quotes.
      */
     quoteTransfer(options: TransferOptions): Promise<Omit<TransferResult, "hash">>;
-    /**
-     * Returns a transaction's receipt.
-     *
-     * @deprecated Use {@link getTransaction} instead, which returns a normalized, finality-based receipt. The native receipt fields remain available on each module's extended return type.
-     * @param {string} hash - The transaction's hash.
-     * @returns {Promise<unknown | null>} The receipt, or null if the transaction has not been included in a block yet.
-     */
-    getTransactionReceipt(hash: string): Promise<unknown | null>;
-    /**
-     * Returns a normalized, finality-based receipt for a transaction.
-     *
-     * @param {string} hash - The transaction's identifier (hash / signature / lt:hash).
-     * @returns {Promise<TransactionReceipt>} The normalized receipt.
-     * @throws {ValueError} If the hash is not a valid identifier.
-     * @throws {NoSuchElementError} If no transaction has been found for the given hash.
-     */
-    getTransaction(hash: string): Promise<TransactionReceipt>;
-    /**
-     * Blocks until a transaction reaches a terminal state (the requested finality target or `dropped`), or times out.
-     *
-     * @param {string} hash - The transaction's identifier.
-     * @param {WaitForTransactionOptions} [options] - The wait options.
-     * @returns {Promise<TransactionReceipt>} The terminal receipt.
-     * @throws {TimeoutError} If the target is not reached before the timeout.
-     */
-    waitForTransaction(hash: string, options?: WaitForTransactionOptions): Promise<TransactionReceipt>;
 }
 /**
  * @abstract
  * @implements {IWalletAccountReadOnly}
  */
 export default abstract class WalletAccountReadOnly implements IWalletAccountReadOnly {
+    /**
+     * The default poll cadence for {@link waitForTransaction}, in milliseconds.
+     * Subclasses may override this to match their finality expectations.
+     *
+     * @protected
+     * @type {number}
+     */
+    protected static _DEFAULT_WAIT_INTERVAL: number;
+    /**
+     * The default total time budget for {@link waitForTransaction}, in milliseconds.
+     * Subclasses may override this to match their finality expectations.
+     *
+     * @protected
+     * @type {number}
+     */
+    protected static _DEFAULT_WAIT_TIMEOUT: number;
     /**
      * Creates a new read-only wallet account.
      *
@@ -141,9 +131,10 @@ export default abstract class WalletAccountReadOnly implements IWalletAccountRea
      * Blocks until a transaction reaches a terminal state (the requested finality
      * target or `dropped`), or times out.
      *
-     * A reverted transaction still reaches its finality target, so it is returned
-     * like any other; callers dispatch on the receipt's `finality` and `success`
-     * fields to tell success, revert, and drop apart. Only a timeout throws.
+     * The polling loop and target resolution are chain-agnostic: this method only
+     * interprets the normalized receipt returned by {@link getTransaction}. A
+     * {@link NoSuchElementError} is treated as a transient not-found, so the loop
+     * keeps polling until the timeout.
      *
      * @param {string} hash - The transaction's identifier.
      * @param {WaitForTransactionOptions} [options] - The wait options.
@@ -151,22 +142,6 @@ export default abstract class WalletAccountReadOnly implements IWalletAccountRea
      * @throws {TimeoutError} If the target is not reached before the timeout.
      */
     waitForTransaction(hash: string, options?: WaitForTransactionOptions): Promise<TransactionReceipt>;
-    /**
-     * The default poll cadence for {@link waitForTransaction}, in milliseconds.
-     * Subclasses may override this to match their finality expectations.
-     *
-     * @protected
-     * @type {number}
-     */
-    protected static _DEFAULT_WAIT_INTERVAL: number;
-    /**
-     * The default total time budget for {@link waitForTransaction}, in milliseconds.
-     * Subclasses may override this to match their finality expectations.
-     *
-     * @protected
-     * @type {number}
-     */
-    protected static _DEFAULT_WAIT_TIMEOUT: number;
 }
 export type Transaction = {
     /**
@@ -212,58 +187,4 @@ export type TransferResult = {
      */
     fee: bigint;
 };
-/**
- * A normalized, cross-chain transaction finality level.
- *
- * - `pending`: seen, not settled (mempool / processed / in-flight).
- * - `confirmed`: settled, reversible only under extreme conditions.
- * - `final`: irreversible per the chain's own guarantees.
- * - `dropped`: evicted / replaced, never landed.
- */
-export type Finality = "pending" | "confirmed" | "final" | "dropped";
-/**
- * A normalized, cross-chain transaction receipt. Blockchain modules extend this
- * type with their own native receipt fields (e.g. `confirmations`, the raw
- * transaction and receipt objects, etc.).
- */
-export type TransactionReceipt = {
-    /**
-     * - The transaction's identifier (hash / signature / lt:hash).
-     */
-    hash: string;
-    /**
-     * - The transaction's finality level.
-     */
-    finality: Finality;
-    /**
-     * - The execution's result (not set if the transaction is still pending or it has been dropped).
-     */
-    success?: boolean;
-    /**
-     * - A reference to the including block (block number / height / slot / masterchain seqno).
-     */
-    block?: number;
-    /**
-     * - The fee paid, when known.
-     */
-    fee?: bigint;
-};
-/**
- * The finality level to wait for.
- */
-export type WaitForTransactionTarget = "confirmed" | "final";
-export type WaitForTransactionOptions = {
-    /**
-     * - The finality target to wait for (default: 'confirmed').
-     */
-    target?: WaitForTransactionTarget;
-    /**
-     * - The total time budget in milliseconds before giving up (default: 60000).
-     */
-    timeout?: number;
-    /**
-     * - The poll cadence in milliseconds (default: 4000).
-     */
-    interval?: number;
-};
-import { IWalletAccountReadOnlySimple } from './wallet-account-read-only-simple.js';
+import { IWalletAccountReadOnlySimple, TransactionReceipt, WaitForTransactionOptions } from './wallet-account-read-only-simple.js';

--- a/types/src/wallet-account-read-only.d.ts
+++ b/types/src/wallet-account-read-only.d.ts
@@ -63,6 +63,7 @@ export interface IWalletAccountReadOnly {
      * @param {string} hash - The transaction's identifier.
      * @param {WaitForTransactionOptions} [options] - The wait options.
      * @returns {Promise<TransactionReceipt>} The terminal receipt.
+     * @throws {TimeoutError} If the target is not reached before the timeout.
      */
     waitForTransaction(hash: string, options?: WaitForTransactionOptions): Promise<TransactionReceipt>;
 }

--- a/types/src/wallet-account-read-only.d.ts
+++ b/types/src/wallet-account-read-only.d.ts
@@ -36,9 +36,11 @@ export interface IWalletAccountReadOnly extends IWalletAccountReadOnlySimple {
      * Returns a normalized, finality-based receipt for a transaction.
      *
      * @param {string} hash - The transaction's identifier (hash / signature / lt:hash).
-     * @returns {Promise<TransactionReceipt | null>} The normalized receipt, or null if the transaction is not known.
+     * @returns {Promise<TransactionReceipt>} The normalized receipt.
+     * @throws {ValueError} If the hash is not a valid identifier.
+     * @throws {NoSuchElementError} If no transaction has been found for the given hash.
      */
-    getTransaction(hash: string): Promise<TransactionReceipt | null>;
+    getTransaction(hash: string): Promise<TransactionReceipt>;
     /**
      * Blocks until a transaction reaches a terminal state (the requested finality target or `dropped`), or times out.
      *
@@ -130,9 +132,11 @@ export default abstract class WalletAccountReadOnly implements IWalletAccountRea
      *
      * @abstract
      * @param {string} hash - The transaction's identifier (hash / signature / lt:hash).
-     * @returns {Promise<TransactionReceipt | null>} The normalized receipt, or null if the transaction is not known.
+     * @returns {Promise<TransactionReceipt>} The normalized receipt.
+     * @throws {ValueError} If the hash is not a valid identifier.
+     * @throws {NoSuchElementError} If no transaction has been found for the given hash.
      */
-    abstract getTransaction(hash: string): Promise<TransactionReceipt | null>;
+    abstract getTransaction(hash: string): Promise<TransactionReceipt>;
     /**
      * Blocks until a transaction reaches a terminal state (the requested finality
      * target or `dropped`), or times out.

--- a/types/src/wallet-account-read-only.d.ts
+++ b/types/src/wallet-account-read-only.d.ts
@@ -1,3 +1,13 @@
+/**
+ * Enum that assigns a comparable ordinal to each finality level, used to check
+ * whether an observed finality satisfies a requested target.
+ */
+export namespace FINALITY {
+    let pending: number;
+    let dropped: number;
+    let confirmed: number;
+    let final: number;
+}
 /** @interface */
 export interface IWalletAccountReadOnly extends IWalletAccountReadOnlySimple {
     /**
@@ -137,15 +147,6 @@ export default abstract class WalletAccountReadOnly implements IWalletAccountRea
      * @throws {TimeoutError} If the target is not reached before the timeout.
      */
     waitForTransaction(hash: string, options?: WaitForTransactionOptions): Promise<TransactionReceipt>;
-    /**
-     * Decides whether a finality level satisfies the requested target.
-     *
-     * @protected
-     * @param {Finality} finality - The observed finality level.
-     * @param {WaitForTransactionTarget} target - The requested finality target.
-     * @returns {boolean} True if the observed finality satisfies the target.
-     */
-    protected _meetsFinality(finality: Finality, target: WaitForTransactionTarget): boolean;
     /**
      * The default poll cadence for {@link waitForTransaction}, in milliseconds.
      *

--- a/types/src/wallet-account-read-only.d.ts
+++ b/types/src/wallet-account-read-only.d.ts
@@ -161,7 +161,7 @@ export default abstract class WalletAccountReadOnly implements IWalletAccountRea
      * @param {string} hash - The transaction's identifier.
      * @param {WaitForTransactionOptions} [options] - The wait options.
      * @returns {Promise<TransactionReceipt>} The terminal receipt: the finality target reached (inspect `success` to tell success from revert), or `dropped`.
-     * @throws {TimeoutError} If the target is not reached before the timeout. The last-seen receipt (or null) is exposed on `.receipt`.
+     * @throws {TimeoutError} If the target is not reached before the timeout.
      */
     waitForTransaction(hash: string, options?: WaitForTransactionOptions): Promise<TransactionReceipt>;
     /**

--- a/types/src/wallet-account-read-only.d.ts
+++ b/types/src/wallet-account-read-only.d.ts
@@ -58,7 +58,7 @@ export interface IWalletAccountReadOnly {
      */
     getTransaction(hash: string): Promise<TransactionReceipt | null>;
     /**
-     * Blocks until a transaction reaches the requested finality target, fails, is dropped, or times out.
+     * Blocks until a transaction reaches a terminal state (the requested finality target or `dropped`), or times out.
      *
      * @param {string} hash - The transaction's identifier.
      * @param {WaitForTransactionOptions} [options] - The wait options.
@@ -151,14 +151,17 @@ export default abstract class WalletAccountReadOnly implements IWalletAccountRea
      */
     abstract getTransaction(hash: string): Promise<TransactionReceipt | null>;
     /**
-     * Blocks until a transaction reaches the requested finality target, fails, is dropped, or times out.
+     * Blocks until a transaction reaches a terminal state (the requested finality
+     * target or `dropped`), or times out.
+     *
+     * A reverted transaction still reaches its finality target, so it is returned
+     * like any other; callers dispatch on the receipt's `finality` and `success`
+     * fields to tell success, revert, and drop apart. Only a timeout throws.
      *
      * @param {string} hash - The transaction's identifier.
      * @param {WaitForTransactionOptions} [options] - The wait options.
-     * @returns {Promise<TransactionReceipt>} The terminal receipt once the target is reached.
-     * @throws {TransactionFailedError} If the transaction lands but reverts (success === false). The receipt is exposed on `.receipt`.
-     * @throws {TransactionDroppedError} If the transaction is reported dropped on two consecutive polls. The receipt is exposed on `.receipt`.
-     * @throws {TransactionConfirmationTimeoutError} If the target is not reached before the timeout. The last-seen receipt (or null) is exposed on `.receipt`.
+     * @returns {Promise<TransactionReceipt>} The terminal receipt: the finality target reached (inspect `success` to tell success from revert), or `dropped`.
+     * @throws {TimeoutError} If the target is not reached before the timeout. The last-seen receipt (or null) is exposed on `.receipt`.
      */
     waitForTransaction(hash: string, options?: WaitForTransactionOptions): Promise<TransactionReceipt>;
     /**

--- a/types/src/wallet-account-read-only.d.ts
+++ b/types/src/wallet-account-read-only.d.ts
@@ -233,9 +233,9 @@ export type TransactionReceipt = {
      */
     success?: boolean;
     /**
-     * - A reference to the including block (block hash / slot / masterchain seqno).
+     * - A reference to the including block (block number / height / slot / masterchain seqno).
      */
-    block?: string | number;
+    block?: number;
     /**
      * - The fee paid, when known.
      */

--- a/types/src/wallet-account-read-only.d.ts
+++ b/types/src/wallet-account-read-only.d.ts
@@ -153,18 +153,20 @@ export default abstract class WalletAccountReadOnly implements IWalletAccountRea
     waitForTransaction(hash: string, options?: WaitForTransactionOptions): Promise<TransactionReceipt>;
     /**
      * The default poll cadence for {@link waitForTransaction}, in milliseconds.
+     * Subclasses may override this to match their finality expectations.
      *
      * @protected
      * @type {number}
      */
-    protected get _defaultWaitInterval(): number;
+    protected static _DEFAULT_WAIT_INTERVAL: number;
     /**
      * The default total time budget for {@link waitForTransaction}, in milliseconds.
+     * Subclasses may override this to match their finality expectations.
      *
      * @protected
      * @type {number}
      */
-    protected get _defaultWaitTimeout(): number;
+    protected static _DEFAULT_WAIT_TIMEOUT: number;
 }
 export type Transaction = {
     /**
@@ -256,11 +258,11 @@ export type WaitForTransactionOptions = {
      */
     target?: WaitForTransactionTarget;
     /**
-     * - The total time budget in milliseconds before giving up (default: per-module).
+     * - The total time budget in milliseconds before giving up (default: 60000).
      */
     timeout?: number;
     /**
-     * - The poll cadence in milliseconds (default: per-module).
+     * - The poll cadence in milliseconds (default: 4000).
      */
     interval?: number;
 };

--- a/types/src/wallet-account-read-only.d.ts
+++ b/types/src/wallet-account-read-only.d.ts
@@ -253,13 +253,13 @@ export type TransactionReceipt = {
      */
     finality: Finality;
     /**
-     * - The execution result, or null while pending/dropped.
+     * - The execution's result (not set if the transaction is still pending or it has been dropped).
      */
-    success: boolean | null;
+    success?: boolean;
     /**
      * - A reference to the including block (block hash / slot / masterchain seqno).
      */
-    blockRef?: string | number;
+    block?: string | number;
     /**
      * - The fee paid, when known.
      */

--- a/types/src/wallet-account-read-only.d.ts
+++ b/types/src/wallet-account-read-only.d.ts
@@ -45,10 +45,26 @@ export interface IWalletAccountReadOnly {
     /**
      * Returns a transaction's receipt.
      *
+     * @deprecated Use {@link getTransaction} instead, which returns a normalized, finality-based receipt. The native receipt fields remain available on each module's extended return type.
      * @param {string} hash - The transaction's hash.
      * @returns {Promise<unknown | null>} The receipt, or null if the transaction has not been included in a block yet.
      */
     getTransactionReceipt(hash: string): Promise<unknown | null>;
+    /**
+     * Returns a normalized, finality-based receipt for a transaction.
+     *
+     * @param {string} hash - The transaction's identifier (hash / signature / lt:hash).
+     * @returns {Promise<TransactionReceipt | null>} The normalized receipt, or null if the transaction is not known.
+     */
+    getTransaction(hash: string): Promise<TransactionReceipt | null>;
+    /**
+     * Blocks until a transaction reaches the requested finality target, fails, is dropped, or times out.
+     *
+     * @param {string} hash - The transaction's identifier.
+     * @param {WaitForTransactionOptions} [options] - The wait options.
+     * @returns {Promise<TransactionReceipt>} The terminal receipt.
+     */
+    waitForTransaction(hash: string, options?: WaitForTransactionOptions): Promise<TransactionReceipt>;
 }
 /**
  * @abstract
@@ -120,11 +136,54 @@ export default abstract class WalletAccountReadOnly implements IWalletAccountRea
     /**
      * Returns a transaction's receipt.
      *
+     * @deprecated Use {@link getTransaction} instead, which returns a normalized, finality-based receipt. The native receipt fields remain available on each module's extended return type.
      * @abstract
      * @param {string} hash - The transaction's hash.
      * @returns {Promise<unknown | null>} The receipt, or null if the transaction has not been included in a block yet.
      */
     abstract getTransactionReceipt(hash: string): Promise<unknown | null>;
+    /**
+     * Returns a normalized, finality-based receipt for a transaction.
+     *
+     * @abstract
+     * @param {string} hash - The transaction's identifier (hash / signature / lt:hash).
+     * @returns {Promise<TransactionReceipt | null>} The normalized receipt, or null if the transaction is not known.
+     */
+    abstract getTransaction(hash: string): Promise<TransactionReceipt | null>;
+    /**
+     * Blocks until a transaction reaches the requested finality target, fails, is dropped, or times out.
+     *
+     * @param {string} hash - The transaction's identifier.
+     * @param {WaitForTransactionOptions} [options] - The wait options.
+     * @returns {Promise<TransactionReceipt>} The terminal receipt once the target is reached.
+     * @throws {TransactionFailedError} If the transaction lands but reverts (success === false). The receipt is exposed on `.receipt`.
+     * @throws {TransactionDroppedError} If the transaction is evicted or replaced. The receipt is exposed on `.receipt`.
+     * @throws {TransactionConfirmationTimeoutError} If the target is not reached before the timeout. The last-seen receipt (or null) is exposed on `.receipt`.
+     */
+    waitForTransaction(hash: string, options?: WaitForTransactionOptions): Promise<TransactionReceipt>;
+    /**
+     * Decides whether a finality level satisfies the requested target.
+     *
+     * @protected
+     * @param {Finality} finality - The observed finality level.
+     * @param {WaitForTransactionTarget} target - The requested finality target.
+     * @returns {boolean} True if the observed finality satisfies the target.
+     */
+    protected _meetsFinality(finality: Finality, target: WaitForTransactionTarget): boolean;
+    /**
+     * The default poll cadence for {@link waitForTransaction}, in milliseconds.
+     *
+     * @protected
+     * @type {number}
+     */
+    protected get _defaultWaitInterval(): number;
+    /**
+     * The default total time budget for {@link waitForTransaction}, in milliseconds.
+     *
+     * @protected
+     * @type {number}
+     */
+    protected get _defaultWaitTimeout(): number;
 }
 export type Transaction = {
     /**
@@ -169,4 +228,58 @@ export type TransferResult = {
      * - The gas cost.
      */
     fee: bigint;
+};
+/**
+ * A normalized, cross-chain transaction finality level.
+ *
+ * - `pending`: seen, not settled (mempool / processed / in-flight).
+ * - `confirmed`: settled, reversible only under extreme conditions.
+ * - `final`: irreversible per the chain's own guarantees.
+ * - `dropped`: evicted / replaced, never landed.
+ */
+export type Finality = "pending" | "confirmed" | "final" | "dropped";
+/**
+ * A normalized, cross-chain transaction receipt. Blockchain modules extend this
+ * type with their own native receipt fields (e.g. `confirmations`, the raw
+ * transaction and receipt objects, etc.).
+ */
+export type TransactionReceipt = {
+    /**
+     * - The transaction's identifier (hash / signature / lt:hash).
+     */
+    id: string;
+    /**
+     * - The transaction's finality level.
+     */
+    finality: Finality;
+    /**
+     * - The execution result, or null while pending/dropped.
+     */
+    success: boolean | null;
+    /**
+     * - A reference to the including block (block hash / slot / masterchain seqno).
+     */
+    blockRef?: string | number;
+    /**
+     * - The fee paid, when known.
+     */
+    fee?: bigint;
+};
+/**
+ * The finality level to wait for.
+ */
+export type WaitForTransactionTarget = "confirmed" | "final";
+export type WaitForTransactionOptions = {
+    /**
+     * - The finality target to wait for (default: 'confirmed').
+     */
+    target?: WaitForTransactionTarget;
+    /**
+     * - The total time budget in milliseconds before giving up (default: per-module).
+     */
+    timeout?: number;
+    /**
+     * - The poll cadence in milliseconds (default: per-module).
+     */
+    interval?: number;
 };

--- a/types/src/wallet-account-read-only.d.ts
+++ b/types/src/wallet-account-read-only.d.ts
@@ -223,7 +223,7 @@ export type TransactionReceipt = {
     /**
      * - The transaction's identifier (hash / signature / lt:hash).
      */
-    id: string;
+    hash: string;
     /**
      * - The transaction's finality level.
      */


### PR DESCRIPTION
# Description
Adds a shared `waitForTransaction` helper to the base wallet account. It polls
`getTransaction` until the transaction reaches the requested finality target
(`confirmed` or `final`), and surfaces clear errors when a transaction reverts,
is dropped, or times out.

To avoid a single RPC blip aborting a long wait, polling now tolerates a few
consecutive `getTransaction` failures before giving up. This is configurable via
a new `maxPollErrors` option (default: 3).

## Motivation and Context
Each chain module previously had to implement its own logic for waiting on a
transaction. Centralizing it here gives every module consistent finality
handling and error reporting, and makes waits resilient to transient node
hiccups.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1217123489895949