### PR TITLE
Add the 'getMultisigAddress' method to 'IWalletAccountMultisig'.

### DIFF
--- a/src/multisig/wallet-account-multisig.js
+++ b/src/multisig/wallet-account-multisig.js
@@ -68,6 +68,15 @@ export class IWalletAccountMultisig extends IWalletAccountReadOnlyMultisig {
   }
 
   /**
+   * Returns the address of the multisig wallet.
+   *
+   * @returns {Promise<string>} The multisig wallet's address.
+   */
+  async getMultisigAddress () {
+    throw new NotImplementedError('getMultisigAddress()')
+  }
+
+  /**
    * Proposes sending a transaction for the other owners to approve. Does not execute on-chain:
    * the returned proposal must be approved up to the threshold and then executed via
    * {@link executeProposal}.

--- a/src/multisig/wallet-account-read-only-multisig.js
+++ b/src/multisig/wallet-account-read-only-multisig.js
@@ -49,15 +49,6 @@ import { NotImplementedError } from '../errors.js'
 /** @interface */
 export class IWalletAccountReadOnlyMultisig extends IWalletAccountReadOnlySimple {
   /**
-   * Returns the address of the signer associated with this wallet account.
-   *
-   * @returns {Promise<string | null>} The signer's address, or null if no signer is associated yet.
-   */
-  async getSignerAddress () {
-    throw new NotImplementedError('getSignerAddress()')
-  }
-
-  /**
    * Returns the multisig wallet account info.
    *
    * @returns {Promise<MultisigInfo>} The info.

--- a/types/src/multisig/wallet-account-multisig.d.ts
+++ b/types/src/multisig/wallet-account-multisig.d.ts
@@ -19,6 +19,12 @@ export interface IWalletAccountMultisig extends IWalletAccountReadOnlyMultisig {
      */
     get keyPair(): KeyPair;
     /**
+     * Returns the address of the multisig wallet.
+     *
+     * @returns {Promise<string>} The multisig wallet's address.
+     */
+    getMultisigAddress(): Promise<string>; 
+    /**
      * Proposes sending a transaction for the other owners to approve. Does not execute on-chain:
      * the returned proposal must be approved up to the threshold and then executed via
      * {@link executeProposal}.

--- a/types/src/multisig/wallet-account-read-only-multisig.d.ts
+++ b/types/src/multisig/wallet-account-read-only-multisig.d.ts
@@ -1,12 +1,6 @@
 /** @interface */
 export interface IWalletAccountReadOnlyMultisig extends IWalletAccountReadOnlySimple {
     /**
-     * Returns the address of the signer associated with this wallet account.
-     *
-     * @returns {Promise<string | null>} The signer's address, or null if no signer is associated yet.
-     */
-    getSignerAddress(): Promise<string | null>;
-    /**
      * Returns the multisig wallet account info.
      *
      * @returns {Promise<MultisigInfo>} The info.


### PR DESCRIPTION
# Description
<!--- Describe your changes in detail. -->
PR removes the 'getSignerAddress' method from the 'IWalletAccountReadOnlyMultisig' interface, and replaces it with 'getMultisigAddress' in 'IWalletAccountMultisig'. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Read-only wallet accounts should be agnostic about and never refer to signers. Also, in 'IWalletAccountMultisig' we are returning the index, path and key pair of the owner account so it's more consistent for the 'getAddress' method to return its address instead of the multisig wallet's. In order to allow users to still fetch such address, PR adds a 'getMultisigAddress' method in the 'IWalletAccountMultisig' interface with the following specification:
```javascript
/** @interface */
export class IWalletAccountMultisig extends IWalletAccountReadOnlyMultisig {
  /**
   * Returns the address of the multisig wallet.
   *
   * @returns {Promise<string>} The multisig wallet's address.
   */
  async getMultisigAddress () {
```

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first. -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce. -->
<!--- Please link to the issue here: -->
PR fixes the following issue: -

## Type of change
<!-- Select the most suitable choice and remove the others from the checklist. -->
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update