### PR TITLE
Add auto execute's transaction result to return types.

### DIFF
--- a/src/multisig/index.js
+++ b/src/multisig/index.js
@@ -19,6 +19,7 @@
 /** @typedef {import('../wallet-account.js').KeyPair} KeyPair */
 
 /** @typedef {import('./wallet-account-multisig.js').MultisigTransactionOptions} MultisigTransactionOptions */
+/** @typedef {import('./wallet-account-multisig.js').MultisigAutoExecuteResult} MultisigAutoExecuteResult */
 /** @typedef {import('./wallet-account-multisig.js').MultisigSignature} MultisigSignature */
 /** @typedef {import('./multisig-owner-management.js').MultisigOptions} MultisigOptions */
 

--- a/src/multisig/wallet-account-multisig.js
+++ b/src/multisig/wallet-account-multisig.js
@@ -34,6 +34,11 @@ import { NotImplementedError } from '../errors.js'
  */
 
 /**
+ * @typedef {Object} MultisigAutoExecuteResult
+ * @property {TransactionResult} [transaction] - If auto execute is set to true and the method call triggers the execution of the proposal, this field is set to the corresponding transaction's result (i.e., hash and fee).
+ */
+
+/**
  * @typedef {Object} MultisigSignature
  * @property {string} signature - The caller's signature.
  */
@@ -74,7 +79,7 @@ export class IWalletAccountMultisig extends IWalletAccountReadOnlyMultisig {
    *
    * @param {Transaction} tx - The transaction.
    * @param {MultisigTransactionOptions} [transactionOptions] - The multisig transaction's options.
-   * @returns {Promise<MultisigProposal>} The created proposal; its `status` is `'executed'` when `autoExecute` ran to completion, otherwise `'pending'`.
+   * @returns {Promise<MultisigProposal & MultisigAutoExecuteResult>} The created proposal; its `status` is `'executed'` when `autoExecute` ran to completion, otherwise `'pending'`.
    * @throws {Error} If the account is not an owner of the multisig wallet.
    */
   async propose (tx, transactionOptions) {
@@ -108,7 +113,7 @@ export class IWalletAccountMultisig extends IWalletAccountReadOnlyMultisig {
    * Approves a pending proposal.
    *
    * @param {string} proposalId - The proposal's id.
-   * @returns {Promise<MultisigProposal>} The multisig proposal.
+   * @returns {Promise<MultisigProposal & MultisigAutoExecuteResult>} The multisig proposal.
    * @throws {Error} If the account is not an owner of the multisig wallet.
    * @throws {NoSuchElementError} If no proposal exists for the given id.
    */

--- a/types/src/multisig/index.d.ts
+++ b/types/src/multisig/index.d.ts
@@ -6,5 +6,6 @@ export type MultisigProposal = import("./wallet-account-read-only-multisig.js").
 export type MultisigMessageProposal = import("./wallet-account-read-only-multisig.js").MultisigMessageProposal;
 export type KeyPair = import("../wallet-account.js").KeyPair;
 export type MultisigTransactionOptions = import("./wallet-account-multisig.js").MultisigTransactionOptions;
+export type MultisigAutoExecuteResult = import("./wallet-account-multisig.js").MultisigAutoExecuteResult;
 export type MultisigSignature = import("./wallet-account-multisig.js").MultisigSignature;
 export type MultisigOptions = import("./multisig-owner-management.js").MultisigOptions;

--- a/types/src/multisig/wallet-account-multisig.d.ts
+++ b/types/src/multisig/wallet-account-multisig.d.ts
@@ -25,10 +25,10 @@ export interface IWalletAccountMultisig extends IWalletAccountReadOnlyMultisig {
      *
      * @param {Transaction} tx - The transaction.
      * @param {MultisigTransactionOptions} [transactionOptions] - The multisig transaction's options.
-     * @returns {Promise<MultisigProposal>} The created proposal; its `status` is `'executed'` when `autoExecute` ran to completion, otherwise `'pending'`.
+     * @returns {Promise<MultisigProposal & MultisigAutoExecuteResult>} The created proposal; its `status` is `'executed'` when `autoExecute` ran to completion, otherwise `'pending'`.
      * @throws {Error} If the account is not an owner of the multisig wallet.
      */
-    propose(tx: Transaction, transactionOptions?: MultisigTransactionOptions): Promise<MultisigProposal>;
+    propose(tx: Transaction, transactionOptions?: MultisigTransactionOptions): Promise<MultisigProposal & MultisigAutoExecuteResult>;
     /**
      * Proposes signing a message.
      *
@@ -50,11 +50,11 @@ export interface IWalletAccountMultisig extends IWalletAccountReadOnlyMultisig {
      * Approves a pending proposal.
      *
      * @param {string} proposalId - The proposal's id.
-     * @returns {Promise<MultisigProposal>} The multisig proposal.
+     * @returns {Promise<MultisigProposal & MultisigAutoExecuteResult>} The multisig proposal.
      * @throws {Error} If the account is not an owner of the multisig wallet.
      * @throws {NoSuchElementError} If no proposal exists for the given id.
      */
-    approveProposal(proposalId: string): Promise<MultisigProposal>;
+    approveProposal(proposalId: string): Promise<MultisigProposal & MultisigAutoExecuteResult>;
     /**
      * Rejects a pending proposal.
      *
@@ -75,14 +75,22 @@ export interface IWalletAccountMultisig extends IWalletAccountReadOnlyMultisig {
 }
 export type Transaction = import("../wallet-account-read-only.js").Transaction;
 export type TransactionResult = import("../wallet-account-read-only.js").TransactionResult;
-export type IWalletAccountReadOnlyMultisig = import("./wallet-account-read-only-multisig.js").IWalletAccountReadOnlyMultisig;
-export type MultisigProposal = import("./wallet-account-read-only-multisig.js").MultisigProposal;
 export type KeyPair = import("../wallet-account.js").KeyPair;
+export type MultisigProposal = import("./wallet-account-read-only-multisig.js").MultisigProposal;
+export type MultisigMessageProposal = import("./wallet-account-read-only-multisig.js").MultisigMessageProposal;
+export type NoSuchElementError = import("../errors.js").NoSuchElementError;
+export type ValueError = import("../errors.js").ValueError;
 export type MultisigTransactionOptions = {
     /**
      * - If true, automatically executes the transaction when the approval threshold is met (only takes effect if this signer's approval is the last one required).
      */
     autoExecute?: boolean;
+};
+export type MultisigAutoExecuteResult = {
+    /**
+     * - If auto execute is set to true and the method call triggers the execution of the proposal, this field is set to the corresponding transaction's result (i.e., hash and fee).
+     */
+    transaction?: TransactionResult;
 };
 export type MultisigSignature = {
     /**
@@ -90,4 +98,4 @@ export type MultisigSignature = {
      */
     signature: string;
 };
-export type MultisigMessageProposal = import("./wallet-account-read-only-multisig.js").MultisigMessageProposal;
+import { IWalletAccountReadOnlyMultisig } from './wallet-account-read-only-multisig.js';


### PR DESCRIPTION
# Description
<!--- Describe your changes in detail. -->
PR adds auto execute's transaction result to the return type of the 'propose' and 'approveProposal' methods in the 'IWalletAccountMultisig' interface.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Without this PR, users that set auto execute to true had no way to fetch the corresponding transaction's hash and fee. The pull request adds an optional 'transaction' field to the return type of the 'propose' and 'approveProposal' methods that holds such data. This field is set only if auto execute has been enabled and the method call triggers the execution of the tx.

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first. -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce. -->
<!--- Please link to the issue here: -->
PR fixes the following issue: -

## Type of change
<!-- Select the most suitable choice and remove the others from the checklist. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1217218764605753