### PR TITLE
Move the 'getSignerAddress' method to 'IWalletAccountMultisig'.

### DIFF
--- a/src/multisig/wallet-account-multisig.js
+++ b/src/multisig/wallet-account-multisig.js
@@ -68,6 +68,15 @@ export class IWalletAccountMultisig extends IWalletAccountReadOnlyMultisig {
   }
 
   /**
+   * Returns the signer's address.
+   *
+   * @returns {Promise<string>} The signer's address.
+   */
+  async getSignerAddress () {
+    throw new NotImplementedError('getSignerAddress()')
+  }
+
+  /**
    * Proposes sending a transaction for the other owners to approve. Does not execute on-chain:
    * the returned proposal must be approved up to the threshold and then executed via
    * {@link executeProposal}.

--- a/src/multisig/wallet-account-read-only-multisig.js
+++ b/src/multisig/wallet-account-read-only-multisig.js
@@ -49,15 +49,6 @@ import { NotImplementedError } from '../errors.js'
 /** @interface */
 export class IWalletAccountReadOnlyMultisig extends IWalletAccountReadOnlySimple {
   /**
-   * Returns the address of the signer associated with this wallet account.
-   *
-   * @returns {Promise<string | null>} The signer's address, or null if no signer is associated yet.
-   */
-  async getSignerAddress () {
-    throw new NotImplementedError('getSignerAddress()')
-  }
-
-  /**
    * Returns the multisig wallet account info.
    *
    * @returns {Promise<MultisigInfo>} The info.

--- a/types/src/multisig/wallet-account-multisig.d.ts
+++ b/types/src/multisig/wallet-account-multisig.d.ts
@@ -19,6 +19,12 @@ export interface IWalletAccountMultisig extends IWalletAccountReadOnlyMultisig {
      */
     get keyPair(): KeyPair;
     /**
+     * Returns the signer's address.
+     *
+     * @returns {Promise<string>} The signer's address.
+     */
+    getSignerAddress(): Promise<string>;
+    /**
      * Proposes sending a transaction for the other owners to approve. Does not execute on-chain:
      * the returned proposal must be approved up to the threshold and then executed via
      * {@link executeProposal}.

--- a/types/src/multisig/wallet-account-read-only-multisig.d.ts
+++ b/types/src/multisig/wallet-account-read-only-multisig.d.ts
@@ -1,12 +1,6 @@
 /** @interface */
 export interface IWalletAccountReadOnlyMultisig extends IWalletAccountReadOnlySimple {
     /**
-     * Returns the address of the signer associated with this wallet account.
-     *
-     * @returns {Promise<string | null>} The signer's address, or null if no signer is associated yet.
-     */
-    getSignerAddress(): Promise<string | null>;
-    /**
      * Returns the multisig wallet account info.
      *
      * @returns {Promise<MultisigInfo>} The info.


### PR DESCRIPTION
# Description
<!--- Describe your changes in detail. -->
PR moves the 'getSignerAddress' method from the 'IWalletAccountReadOnlyMultisig' interface to 'IWalletAccountMultisig'.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Read-only wallet accounts should be agnostic about signers and never refer to them in any way. For this reason, the 'getSignerAddress' method is a better fit for the 'IWalletAccountMultisig' interface. This also allows the return type of the method to be just string instead of string | null.

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first. -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce. -->
<!--- Please link to the issue here: -->
PR fixes the following issue: -

## Type of change
<!-- Select the most suitable choice and remove the others from the checklist. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1217219427768443