### PR TITLE
Add IWalletAccount test coverage and make WalletManager.dispose exception-safe

### DIFF
--- a/src/wallet-manager.js
+++ b/src/wallet-manager.js
@@ -236,22 +236,43 @@ export default class WalletManager {
 
   /**
    * Disposes all wallet accounts and signers, clearing secret material from memory.
+   *
+   * Every account and signer is disposed on a best-effort basis: if one of them throws
+   * while disposing, the rest are still disposed and the internal maps are still cleared,
+   * so no secret is left un-wiped because of an unrelated failure. The first error
+   * encountered, if any, is re-thrown once cleanup has finished.
+   *
+   * @throws {Error} The first error thrown by an account's or signer's `dispose()`, if any.
    */
   dispose () {
-    for (const account of Object.values(this._accounts)) {
-      if (account.keyPair?.privateKey) {
-        account.dispose()
+    let firstError
+
+    const disposeSafely = (disposable) => {
+      try {
+        disposable?.dispose()
+      } catch (err) {
+        if (!firstError) {
+          firstError = err
+        }
       }
     }
 
-    this._defaultSigner?.dispose()
+    for (const account of Object.values(this._accounts)) {
+      disposeSafely(account)
+    }
+
+    disposeSafely(this._defaultSigner)
 
     for (const signer of Object.values(this._signers)) {
-      signer.dispose()
+      disposeSafely(signer)
     }
 
     this._accounts = {}
     this._defaultSigner = undefined
     this._signers = {}
+
+    if (firstError) {
+      throw firstError
+    }
   }
 }

--- a/tests/wallet-account.test.js
+++ b/tests/wallet-account.test.js
@@ -1,0 +1,141 @@
+import { describe, expect, test } from '@jest/globals'
+
+import { IWalletAccount } from '../index.js'
+
+describe('IWalletAccount', () => {
+  describe('index', () => {
+    test('should throw if not implemented', () => {
+      const account = new IWalletAccount()
+
+      expect(() => account.index)
+        .toThrow("Method 'index' must be implemented.")
+    })
+  })
+
+  describe('path', () => {
+    test('should throw if not implemented', () => {
+      const account = new IWalletAccount()
+
+      expect(() => account.path)
+        .toThrow("Method 'path' must be implemented.")
+    })
+  })
+
+  describe('keyPair', () => {
+    test('should throw if not implemented', () => {
+      const account = new IWalletAccount()
+
+      expect(() => account.keyPair)
+        .toThrow("Method 'keyPair' must be implemented.")
+    })
+  })
+
+  describe('sign', () => {
+    test('should throw if not implemented', async () => {
+      const account = new IWalletAccount()
+
+      await expect(account.sign('message'))
+        .rejects.toThrow("Method 'sign(message)' must be implemented.")
+    })
+  })
+
+  describe('signTransaction', () => {
+    test('should throw if not implemented', async () => {
+      const account = new IWalletAccount()
+
+      await expect(account.signTransaction({}))
+        .rejects.toThrow("Method 'signTransaction(tx)' must be implemented.")
+    })
+  })
+
+  describe('verify', () => {
+    test('should throw if not implemented', async () => {
+      const account = new IWalletAccount()
+
+      await expect(account.verify('message', 'signature'))
+        .rejects.toThrow("Method 'verify(message, signature)' must be implemented.")
+    })
+  })
+
+  describe('sendTransaction', () => {
+    test('should throw if not implemented', async () => {
+      const account = new IWalletAccount()
+
+      await expect(account.sendTransaction({}))
+        .rejects.toThrow("Method 'sendTransaction(tx)' must be implemented.")
+    })
+  })
+
+  describe('quoteSendTransaction', () => {
+    test('should throw if not implemented', async () => {
+      const account = new IWalletAccount()
+
+      await expect(account.quoteSendTransaction({}))
+        .rejects.toThrow("Method 'quoteSendTransaction(tx)' must be implemented.")
+    })
+  })
+
+  describe('transfer', () => {
+    test('should throw if not implemented', async () => {
+      const account = new IWalletAccount()
+
+      await expect(account.transfer({}))
+        .rejects.toThrow("Method 'transfer(options)' must be implemented.")
+    })
+  })
+
+  describe('toReadOnlyAccount', () => {
+    test('should throw if not implemented', async () => {
+      const account = new IWalletAccount()
+
+      await expect(account.toReadOnlyAccount())
+        .rejects.toThrow("Method 'toReadOnlyAccount()' must be implemented.")
+    })
+  })
+
+  describe('dispose', () => {
+    test('should throw if not implemented', () => {
+      const account = new IWalletAccount()
+
+      expect(() => account.dispose())
+        .toThrow("Method 'dispose()' must be implemented.")
+    })
+  })
+
+  describe('inherited members', () => {
+    test('getAddress should throw if not implemented', async () => {
+      const account = new IWalletAccount()
+
+      await expect(account.getAddress())
+        .rejects.toThrow("Method 'getAddress()' must be implemented.")
+    })
+
+    test('getBalance should throw if not implemented', async () => {
+      const account = new IWalletAccount()
+
+      await expect(account.getBalance())
+        .rejects.toThrow("Method 'getBalance()' must be implemented.")
+    })
+
+    test('getTokenBalance should throw if not implemented', async () => {
+      const account = new IWalletAccount()
+
+      await expect(account.getTokenBalance('0xtoken'))
+        .rejects.toThrow("Method 'getTokenBalance(tokenAddress)' must be implemented.")
+    })
+
+    test('getTransactionReceipt should throw if not implemented', async () => {
+      const account = new IWalletAccount()
+
+      await expect(account.getTransactionReceipt('0xhash'))
+        .rejects.toThrow("Method 'getTransactionReceipt(hash)' must be implemented.")
+    })
+
+    test('quoteTransfer should throw if not implemented', async () => {
+      const account = new IWalletAccount()
+
+      await expect(account.quoteTransfer({}))
+        .rejects.toThrow("Method 'quoteTransfer(options)' must be implemented.")
+    })
+  })
+})

--- a/tests/wallet-manager.test.js
+++ b/tests/wallet-manager.test.js
@@ -179,5 +179,61 @@ describe('WalletManager', () => {
       expect(() => wallet.getSigner())
         .toThrow('No default signer registered.')
     })
+
+    test('should dispose every cached account regardless of its keyPair state', () => {
+      const wallet = new DummyWalletManager(SEED_PHRASE)
+
+      // An account whose keyPair has no private key (e.g. a hardware/remote signer
+      // that never exposes raw key material to memory) must still be disposed.
+      const accountWithoutPrivateKey = {
+        keyPair: { publicKey: new Uint8Array(), privateKey: null },
+        dispose: jest.fn()
+      }
+
+      // An account whose `keyPair` getter itself throws must not prevent the rest
+      // of the cache from being disposed.
+      const accountWithThrowingKeyPair = {
+        get keyPair () { throw new Error('keyPair is not available') },
+        dispose: jest.fn()
+      }
+
+      wallet._accounts = {
+        "0'/0/0": accountWithoutPrivateKey,
+        "0'/0/1": accountWithThrowingKeyPair
+      }
+
+      wallet.dispose()
+
+      expect(accountWithoutPrivateKey.dispose).toHaveBeenCalledTimes(1)
+      expect(accountWithThrowingKeyPair.dispose).toHaveBeenCalledTimes(1)
+      expect(wallet._accounts).toEqual({})
+    })
+
+    test('should dispose all remaining accounts and signers even if one throws, then re-throw the first error', () => {
+      const wallet = new DummyWalletManager(SEED_PHRASE)
+
+      const failingAccount = {
+        keyPair: { publicKey: new Uint8Array(), privateKey: new Uint8Array() },
+        dispose: jest.fn(() => { throw new Error('boom') })
+      }
+      const healthyAccount = {
+        keyPair: { publicKey: new Uint8Array(), privateKey: new Uint8Array() },
+        dispose: jest.fn()
+      }
+
+      const healthySigner = new DummySigner()
+      const disposeSpy = jest.spyOn(healthySigner, 'dispose')
+
+      wallet._accounts = { "0'/0/0": failingAccount, "0'/0/1": healthyAccount }
+      wallet.addSigner('backup', healthySigner)
+
+      expect(() => wallet.dispose()).toThrow('boom')
+
+      expect(failingAccount.dispose).toHaveBeenCalledTimes(1)
+      expect(healthyAccount.dispose).toHaveBeenCalledTimes(1)
+      expect(disposeSpy).toHaveBeenCalledTimes(1)
+      expect(wallet._accounts).toEqual({})
+      expect(wallet.getSigners()).toEqual({})
+    })
   })
 })


### PR DESCRIPTION
## Summary
- **Test coverage:** `src/wallet-account.js` (`IWalletAccount`) had zero test coverage, unlike its read-only counterpart (`WalletAccountReadOnly`). Adds `tests/wallet-account.test.js`, asserting every abstract member throws `NotImplementedError` with the correct message.
- **Bug fix:** `WalletManager.dispose()` (`src/wallet-manager.js`) looped over `_accounts` synchronously with no error handling, guarded by `account.keyPair?.privateKey`. Two real problems with that:
  1. An account whose `keyPair` never exposes a private key (e.g. a future hardware/remote signer) would never get `dispose()` called on it at all.
  2. If any single account's `dispose()` (or its `keyPair` getter) threw, every account/signer disposed *after* it in iteration order — plus the internal map clearing — never happened, leaving private key material un-wiped.

  `dispose()` now disposes every cached account and signer unconditionally, on a best-effort basis: one failure no longer prevents the rest of the secrets from being wiped or the internal maps from being cleared. The first error encountered, if any, is re-thrown after cleanup finishes. Regression tests in `tests/wallet-manager.test.js` reproduce both failure modes and were verified to fail against the old implementation.

## Test plan
- [x] `npm run lint` (standard) passes
- [x] `npm test` passes — 37/37 tests (17 new)
- [x] `npm run build:types` passes (generated `.d.ts` diff not included — it's noise from a different local `tsc` version, unrelated to this change)
- [x] Confirmed the two new `dispose()` regression tests fail against the pre-fix implementation