### PR TITLE
test: add coverage for multisig interfaces

### DIFF
--- a/tests/multisig-owner-management.test.js
+++ b/tests/multisig-owner-management.test.js
@@ -1,0 +1,41 @@
+import { describe, expect, test } from '@jest/globals'
+
+import { IMultisigOwnerManagement } from '../src/multisig/index.js'
+
+describe('IMultisigOwnerManagement', () => {
+  describe('addOwner', () => {
+    test('should throw if not implemented', async () => {
+      const management = new IMultisigOwnerManagement()
+
+      await expect(management.addOwner('0xowner'))
+        .rejects.toThrow("Method 'addOwner(owner, options)' must be implemented.")
+    })
+  })
+
+  describe('removeOwner', () => {
+    test('should throw if not implemented', async () => {
+      const management = new IMultisigOwnerManagement()
+
+      await expect(management.removeOwner('0xowner'))
+        .rejects.toThrow("Method 'removeOwner(owner, options)' must be implemented.")
+    })
+  })
+
+  describe('swapOwner', () => {
+    test('should throw if not implemented', async () => {
+      const management = new IMultisigOwnerManagement()
+
+      await expect(management.swapOwner('0xold', '0xnew'))
+        .rejects.toThrow("Method 'swapOwner(oldOwner, newOwner)' must be implemented.")
+    })
+  })
+
+  describe('changeThreshold', () => {
+    test('should throw if not implemented', async () => {
+      const management = new IMultisigOwnerManagement()
+
+      await expect(management.changeThreshold(2))
+        .rejects.toThrow("Method 'changeThreshold(newThreshold)' must be implemented.")
+    })
+  })
+})

--- a/tests/wallet-account-multisig.test.js
+++ b/tests/wallet-account-multisig.test.js
@@ -1,0 +1,174 @@
+import { describe, expect, test } from '@jest/globals'
+
+import { IWalletAccountMultisig } from '../src/multisig/index.js'
+
+describe('IWalletAccountMultisig', () => {
+  describe('index', () => {
+    test('should throw if not implemented', () => {
+      const account = new IWalletAccountMultisig()
+
+      expect(() => account.index)
+        .toThrow("Method 'index' must be implemented.")
+    })
+  })
+
+  describe('path', () => {
+    test('should throw if not implemented', () => {
+      const account = new IWalletAccountMultisig()
+
+      expect(() => account.path)
+        .toThrow("Method 'path' must be implemented.")
+    })
+  })
+
+  describe('keyPair', () => {
+    test('should throw if not implemented', () => {
+      const account = new IWalletAccountMultisig()
+
+      expect(() => account.keyPair)
+        .toThrow("Method 'keyPair' must be implemented.")
+    })
+  })
+
+  describe('getSignerAddress', () => {
+    test('should throw if not implemented', async () => {
+      const account = new IWalletAccountMultisig()
+
+      await expect(account.getSignerAddress())
+        .rejects.toThrow("Method 'getSignerAddress()' must be implemented.")
+    })
+  })
+
+  describe('propose', () => {
+    test('should throw if not implemented', async () => {
+      const account = new IWalletAccountMultisig()
+
+      await expect(account.propose({}))
+        .rejects.toThrow("Method 'propose(tx, transactionOptions)' must be implemented.")
+    })
+  })
+
+  describe('proposeMessage', () => {
+    test('should throw if not implemented', async () => {
+      const account = new IWalletAccountMultisig()
+
+      await expect(account.proposeMessage('message'))
+        .rejects.toThrow("Method 'proposeMessage(message)' must be implemented.")
+    })
+  })
+
+  describe('approveMessageProposal', () => {
+    test('should throw if not implemented', async () => {
+      const account = new IWalletAccountMultisig()
+
+      await expect(account.approveMessageProposal('message-1'))
+        .rejects.toThrow("Method 'approveMessageProposal(messageId)' must be implemented.")
+    })
+  })
+
+  describe('approveProposal', () => {
+    test('should throw if not implemented', async () => {
+      const account = new IWalletAccountMultisig()
+
+      await expect(account.approveProposal('proposal-1'))
+        .rejects.toThrow("Method 'approveProposal(proposalId)' must be implemented.")
+    })
+  })
+
+  describe('rejectProposal', () => {
+    test('should throw if not implemented', async () => {
+      const account = new IWalletAccountMultisig()
+
+      await expect(account.rejectProposal('proposal-1'))
+        .rejects.toThrow("Method 'rejectProposal(proposalId)' must be implemented.")
+    })
+  })
+
+  describe('executeProposal', () => {
+    test('should throw if not implemented', async () => {
+      const account = new IWalletAccountMultisig()
+
+      await expect(account.executeProposal('proposal-1'))
+        .rejects.toThrow("Method 'executeProposal(proposalId)' must be implemented.")
+    })
+  })
+
+  describe('inherited members', () => {
+    test('getMultisigInfo should throw if not implemented', async () => {
+      const account = new IWalletAccountMultisig()
+
+      await expect(account.getMultisigInfo())
+        .rejects.toThrow("Method 'getMultisigInfo()' must be implemented.")
+    })
+
+    test('getProposals should throw if not implemented', async () => {
+      const account = new IWalletAccountMultisig()
+
+      await expect(account.getProposals(['proposal-1']))
+        .rejects.toThrow("Method 'getProposals(proposalIds)' must be implemented.")
+    })
+
+    test('getProposal should throw if not implemented', async () => {
+      const account = new IWalletAccountMultisig()
+
+      await expect(account.getProposal('proposal-1'))
+        .rejects.toThrow("Method 'getProposal(proposalId)' must be implemented.")
+    })
+
+    test('getMessageProposals should throw if not implemented', async () => {
+      const account = new IWalletAccountMultisig()
+
+      await expect(account.getMessageProposals(['message-1']))
+        .rejects.toThrow("Method 'getMessageProposals(messageIds)' must be implemented.")
+    })
+
+    test('getMessageProposal should throw if not implemented', async () => {
+      const account = new IWalletAccountMultisig()
+
+      await expect(account.getMessageProposal('message-1'))
+        .rejects.toThrow("Method 'getMessageProposal(messageId)' must be implemented.")
+    })
+
+    test('quoteExecuteProposal should throw if not implemented', async () => {
+      const account = new IWalletAccountMultisig()
+
+      await expect(account.quoteExecuteProposal('proposal-1'))
+        .rejects.toThrow("Method 'quoteExecuteProposal(proposalId)' must be implemented.")
+    })
+
+    test('getAddress should throw if not implemented', async () => {
+      const account = new IWalletAccountMultisig()
+
+      await expect(account.getAddress())
+        .rejects.toThrow("Method 'getAddress()' must be implemented.")
+    })
+
+    test('verify should throw if not implemented', async () => {
+      const account = new IWalletAccountMultisig()
+
+      await expect(account.verify('message', 'signature'))
+        .rejects.toThrow("Method 'verify(message, signature)' must be implemented.")
+    })
+
+    test('getBalance should throw if not implemented', async () => {
+      const account = new IWalletAccountMultisig()
+
+      await expect(account.getBalance())
+        .rejects.toThrow("Method 'getBalance()' must be implemented.")
+    })
+
+    test('getTokenBalance should throw if not implemented', async () => {
+      const account = new IWalletAccountMultisig()
+
+      await expect(account.getTokenBalance('0xtoken'))
+        .rejects.toThrow("Method 'getTokenBalance(tokenAddress)' must be implemented.")
+    })
+
+    test('getTransactionReceipt should throw if not implemented', async () => {
+      const account = new IWalletAccountMultisig()
+
+      await expect(account.getTransactionReceipt('0xhash'))
+        .rejects.toThrow("Method 'getTransactionReceipt(hash)' must be implemented.")
+    })
+  })
+})

--- a/tests/wallet-account-read-only-multisig.test.js
+++ b/tests/wallet-account-read-only-multisig.test.js
@@ -1,0 +1,96 @@
+import { describe, expect, test } from '@jest/globals'
+
+import { IWalletAccountReadOnlyMultisig } from '../src/multisig/index.js'
+
+describe('IWalletAccountReadOnlyMultisig', () => {
+  describe('getMultisigInfo', () => {
+    test('should throw if not implemented', async () => {
+      const account = new IWalletAccountReadOnlyMultisig()
+
+      await expect(account.getMultisigInfo())
+        .rejects.toThrow("Method 'getMultisigInfo()' must be implemented.")
+    })
+  })
+
+  describe('getProposals', () => {
+    test('should throw if not implemented', async () => {
+      const account = new IWalletAccountReadOnlyMultisig()
+
+      await expect(account.getProposals(['proposal-1']))
+        .rejects.toThrow("Method 'getProposals(proposalIds)' must be implemented.")
+    })
+  })
+
+  describe('getProposal', () => {
+    test('should throw if not implemented', async () => {
+      const account = new IWalletAccountReadOnlyMultisig()
+
+      await expect(account.getProposal('proposal-1'))
+        .rejects.toThrow("Method 'getProposal(proposalId)' must be implemented.")
+    })
+  })
+
+  describe('getMessageProposals', () => {
+    test('should throw if not implemented', async () => {
+      const account = new IWalletAccountReadOnlyMultisig()
+
+      await expect(account.getMessageProposals(['message-1']))
+        .rejects.toThrow("Method 'getMessageProposals(messageIds)' must be implemented.")
+    })
+  })
+
+  describe('getMessageProposal', () => {
+    test('should throw if not implemented', async () => {
+      const account = new IWalletAccountReadOnlyMultisig()
+
+      await expect(account.getMessageProposal('message-1'))
+        .rejects.toThrow("Method 'getMessageProposal(messageId)' must be implemented.")
+    })
+  })
+
+  describe('quoteExecuteProposal', () => {
+    test('should throw if not implemented', async () => {
+      const account = new IWalletAccountReadOnlyMultisig()
+
+      await expect(account.quoteExecuteProposal('proposal-1'))
+        .rejects.toThrow("Method 'quoteExecuteProposal(proposalId)' must be implemented.")
+    })
+  })
+
+  describe('inherited members', () => {
+    test('getAddress should throw if not implemented', async () => {
+      const account = new IWalletAccountReadOnlyMultisig()
+
+      await expect(account.getAddress())
+        .rejects.toThrow("Method 'getAddress()' must be implemented.")
+    })
+
+    test('verify should throw if not implemented', async () => {
+      const account = new IWalletAccountReadOnlyMultisig()
+
+      await expect(account.verify('message', 'signature'))
+        .rejects.toThrow("Method 'verify(message, signature)' must be implemented.")
+    })
+
+    test('getBalance should throw if not implemented', async () => {
+      const account = new IWalletAccountReadOnlyMultisig()
+
+      await expect(account.getBalance())
+        .rejects.toThrow("Method 'getBalance()' must be implemented.")
+    })
+
+    test('getTokenBalance should throw if not implemented', async () => {
+      const account = new IWalletAccountReadOnlyMultisig()
+
+      await expect(account.getTokenBalance('0xtoken'))
+        .rejects.toThrow("Method 'getTokenBalance(tokenAddress)' must be implemented.")
+    })
+
+    test('getTransactionReceipt should throw if not implemented', async () => {
+      const account = new IWalletAccountReadOnlyMultisig()
+
+      await expect(account.getTransactionReceipt('0xhash'))
+        .rejects.toThrow("Method 'getTransactionReceipt(hash)' must be implemented.")
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- `IMultisigOwnerManagement`, `IWalletAccountReadOnlyMultisig`, and `IWalletAccountMultisig` (`src/multisig/*`) had zero test coverage.
- Adds interface-stub tests mirroring the existing `IWalletAccount` test style: each method/getter is asserted to throw/reject with its `NotImplementedError` message, including inherited members from the read-only-simple and read-only-multisig base classes.
- `src/multisig/*` now reports 100% statement/branch/function coverage (previously untouched by any test import).

No source changes — tests only.

## Test plan
- [x] `npm run lint` — clean
- [x] `npm run test:coverage` — 55/55 passing, `src/multisig/*` at 100%
- [x] `npm run build:types` — no errors