### PR TITLE
refactor(multisig): make message-signing an optional capability interface

### DIFF
--- a/src/multisig/index.js
+++ b/src/multisig/index.js
@@ -15,12 +15,12 @@
 
 /** @typedef {import('./wallet-account-read-only-multisig.js').MultisigInfo} MultisigInfo */
 /** @typedef {import('./wallet-account-read-only-multisig.js').MultisigProposal} MultisigProposal */
-/** @typedef {import('./wallet-account-read-only-multisig.js').MultisigMessageProposal} MultisigMessageProposal */
+/** @typedef {import('./multisig-message-signing.js').MultisigMessageProposal} MultisigMessageProposal */
 /** @typedef {import('../wallet-account.js').KeyPair} KeyPair */
 
 /** @typedef {import('./wallet-account-multisig.js').MultisigTransactionOptions} MultisigTransactionOptions */
 /** @typedef {import('./wallet-account-multisig.js').MultisigAutoExecuteResult} MultisigAutoExecuteResult */
-/** @typedef {import('./wallet-account-multisig.js').MultisigSignature} MultisigSignature */
+/** @typedef {import('./multisig-message-signing.js').MultisigSignature} MultisigSignature */
 /** @typedef {import('./multisig-owner-management.js').MultisigOptions} MultisigOptions */
 
 export { IWalletAccountReadOnlyMultisig } from './wallet-account-read-only-multisig.js'
@@ -28,3 +28,5 @@ export { IWalletAccountReadOnlyMultisig } from './wallet-account-read-only-multi
 export { IWalletAccountMultisig } from './wallet-account-multisig.js'
 
 export { IMultisigOwnerManagement } from './multisig-owner-management.js'
+
+export { IMultisigReadOnlyMessageSigning, IMultisigMessageSigning } from './multisig-message-signing.js'

--- a/src/multisig/index.js
+++ b/src/multisig/index.js
@@ -15,7 +15,7 @@
 
 /** @typedef {import('./wallet-account-read-only-multisig.js').MultisigInfo} MultisigInfo */
 /** @typedef {import('./wallet-account-read-only-multisig.js').MultisigProposal} MultisigProposal */
-/** @typedef {import('./multisig-message-signing.js').MultisigMessageProposal} MultisigMessageProposal */
+/** @typedef {import('./multisig-message-signing-read-only.js').MultisigMessageProposal} MultisigMessageProposal */
 /** @typedef {import('../wallet-account.js').KeyPair} KeyPair */
 
 /** @typedef {import('./wallet-account-multisig.js').MultisigTransactionOptions} MultisigTransactionOptions */
@@ -29,4 +29,6 @@ export { IWalletAccountMultisig } from './wallet-account-multisig.js'
 
 export { IMultisigOwnerManagement } from './multisig-owner-management.js'
 
-export { IMultisigReadOnlyMessageSigning, IMultisigMessageSigning } from './multisig-message-signing.js'
+export { IMultisigMessageSigningReadOnly } from './multisig-message-signing-read-only.js'
+
+export { IMultisigMessageSigning } from './multisig-message-signing.js'

--- a/src/multisig/multisig-message-signing-read-only.js
+++ b/src/multisig/multisig-message-signing-read-only.js
@@ -1,0 +1,53 @@
+// Copyright 2024 Tether Operations Limited
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+'use strict'
+
+import { NotImplementedError } from '../errors.js'
+
+/**
+ * @typedef {Object} MultisigMessageProposal
+ * @property {string} messageId - The message's hash.
+ * @property {string} message - The original message.
+ * @property {number} confirmations - The current number of confirmations.
+ * @property {number} threshold - The minimum amount of confirmations to sign the message.
+ * @property {string | null} combinedSignature - The final combined signature when the threshold is met.
+ */
+
+/**
+ * Adds the read-only message-signing queries to a multisig wallet.
+ *
+ * @interface
+ */
+export class IMultisigMessageSigningReadOnly {
+  /**
+   * Returns a list of message proposals by their hashes.
+   *
+   * @param {string[]} messageIds - The list of message hashes
+   * @returns {Promise<Record<string, MultisigMessageProposal | null>>} For each message hash, the message details or
+   *   null if the message has not been found.
+   */
+  async getMessageProposals (messageIds) {
+    throw new NotImplementedError('getMessageProposals(messageIds)')
+  }
+
+  /**
+   * Returns a message proposal by its identifier.
+   *
+   * @param {string} messageId - The message's hash.
+   * @returns {Promise<MultisigMessageProposal | null>} The message details, or null if it has not been found.
+   */
+  async getMessageProposal (messageId) {
+    throw new NotImplementedError('getMessageProposal(messageId)')
+  }
+}

--- a/src/multisig/multisig-message-signing.js
+++ b/src/multisig/multisig-message-signing.js
@@ -1,0 +1,90 @@
+// Copyright 2024 Tether Operations Limited
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+'use strict'
+
+import { NotImplementedError } from '../errors.js'
+
+/** @typedef {import('../errors.js').NoSuchElementError} NoSuchElementError */
+
+/**
+ * @typedef {Object} MultisigMessageProposal
+ * @property {string} messageId - The message's hash.
+ * @property {string} message - The original message.
+ * @property {number} confirmations - The current number of confirmations.
+ * @property {number} threshold - The minimum amount of confirmations to sign the message.
+ * @property {string | null} combinedSignature - The final combined signature when the threshold is met.
+ */
+
+/**
+ * @typedef {Object} MultisigSignature
+ * @property {string} signature - The caller's signature.
+ */
+
+/**
+ * Adds the read-only message-signing queries to a multisig wallet.
+ *
+ * @interface
+ */
+export class IMultisigReadOnlyMessageSigning {
+  /**
+   * Returns a list of message proposals by their hashes.
+   *
+   * @param {string[]} messageIds - The list of message hashes
+   * @returns {Promise<Record<string, MultisigMessageProposal | null>>} For each message hash, the message details or
+   *   null if the message has not been found.
+   */
+  async getMessageProposals (messageIds) {
+    throw new NotImplementedError('getMessageProposals(messageIds)')
+  }
+
+  /**
+   * Returns a message proposal by its identifier.
+   *
+   * @param {string} messageId - The message's hash.
+   * @returns {Promise<MultisigMessageProposal | null>} The message details, or null if it has not been found.
+   */
+  async getMessageProposal (messageId) {
+    throw new NotImplementedError('getMessageProposal(messageId)')
+  }
+}
+
+/**
+ * Adds message-signing features to a multisig wallet.
+ *
+ * @interface
+ */
+export class IMultisigMessageSigning extends IMultisigReadOnlyMessageSigning {
+  /**
+   * Proposes signing a message.
+   *
+   * @param {string} message - The message to sign.
+   * @returns {Promise<MultisigMessageProposal & MultisigSignature>} The multisig message proposal.
+   * @throws {Error} If the account is not an owner of the multisig wallet.
+   */
+  async proposeMessage (message) {
+    throw new NotImplementedError('proposeMessage(message)')
+  }
+
+  /**
+   * Approves an existing message proposal.
+   *
+   * @param {string} messageId - The message's hash.
+   * @returns {Promise<MultisigMessageProposal & MultisigSignature>} The multisig message proposal.
+   * @throws {Error} If the account is not an owner of the multisig wallet.
+   * @throws {NoSuchElementError} If no message exists for the given id.
+   */
+  async approveMessageProposal (messageId) {
+    throw new NotImplementedError('approveMessageProposal(messageId)')
+  }
+}

--- a/src/multisig/multisig-message-signing.js
+++ b/src/multisig/multisig-message-signing.js
@@ -13,18 +13,13 @@
 // limitations under the License.
 'use strict'
 
+import { IMultisigMessageSigningReadOnly } from './multisig-message-signing-read-only.js'
+
 import { NotImplementedError } from '../errors.js'
 
 /** @typedef {import('../errors.js').NoSuchElementError} NoSuchElementError */
 
-/**
- * @typedef {Object} MultisigMessageProposal
- * @property {string} messageId - The message's hash.
- * @property {string} message - The original message.
- * @property {number} confirmations - The current number of confirmations.
- * @property {number} threshold - The minimum amount of confirmations to sign the message.
- * @property {string | null} combinedSignature - The final combined signature when the threshold is met.
- */
+/** @typedef {import('./multisig-message-signing-read-only.js').MultisigMessageProposal} MultisigMessageProposal */
 
 /**
  * @typedef {Object} MultisigSignature
@@ -32,39 +27,11 @@ import { NotImplementedError } from '../errors.js'
  */
 
 /**
- * Adds the read-only message-signing queries to a multisig wallet.
- *
- * @interface
- */
-export class IMultisigReadOnlyMessageSigning {
-  /**
-   * Returns a list of message proposals by their hashes.
-   *
-   * @param {string[]} messageIds - The list of message hashes
-   * @returns {Promise<Record<string, MultisigMessageProposal | null>>} For each message hash, the message details or
-   *   null if the message has not been found.
-   */
-  async getMessageProposals (messageIds) {
-    throw new NotImplementedError('getMessageProposals(messageIds)')
-  }
-
-  /**
-   * Returns a message proposal by its identifier.
-   *
-   * @param {string} messageId - The message's hash.
-   * @returns {Promise<MultisigMessageProposal | null>} The message details, or null if it has not been found.
-   */
-  async getMessageProposal (messageId) {
-    throw new NotImplementedError('getMessageProposal(messageId)')
-  }
-}
-
-/**
  * Adds message-signing features to a multisig wallet.
  *
  * @interface
  */
-export class IMultisigMessageSigning extends IMultisigReadOnlyMessageSigning {
+export class IMultisigMessageSigning extends IMultisigMessageSigningReadOnly {
   /**
    * Proposes signing a message.
    *

--- a/src/multisig/wallet-account-multisig.js
+++ b/src/multisig/wallet-account-multisig.js
@@ -23,7 +23,6 @@ import { NotImplementedError } from '../errors.js'
 /** @typedef {import('../wallet-account.js').KeyPair} KeyPair */
 
 /** @typedef {import('./wallet-account-read-only-multisig.js').MultisigProposal} MultisigProposal */
-/** @typedef {import('./wallet-account-read-only-multisig.js').MultisigMessageProposal} MultisigMessageProposal */
 
 /** @typedef {import('../errors.js').NoSuchElementError} NoSuchElementError */
 /** @typedef {import('../errors.js').ValueError} ValueError */
@@ -36,11 +35,6 @@ import { NotImplementedError } from '../errors.js'
 /**
  * @typedef {Object} MultisigAutoExecuteResult
  * @property {TransactionResult} [transaction] - If auto execute is set to true and the method call triggers the execution of the proposal, this field is set to the corresponding transaction's result (i.e., hash and fee).
- */
-
-/**
- * @typedef {Object} MultisigSignature
- * @property {string} signature - The caller's signature.
  */
 
 /** @interface */
@@ -93,29 +87,6 @@ export class IWalletAccountMultisig extends IWalletAccountReadOnlyMultisig {
    */
   async propose (tx, transactionOptions) {
     throw new NotImplementedError('propose(tx, transactionOptions)')
-  }
-
-  /**
-   * Proposes signing a message.
-   *
-   * @param {string} message - The message to sign.
-   * @returns {Promise<MultisigMessageProposal & MultisigSignature>} The multisig message proposal.
-   * @throws {Error} If the account is not an owner of the multisig wallet.
-   */
-  async proposeMessage (message) {
-    throw new NotImplementedError('proposeMessage(message)')
-  }
-
-  /**
-   * Approves an existing message proposal.
-   *
-   * @param {string} messageId - The message's hash.
-   * @returns {Promise<MultisigMessageProposal & MultisigSignature>} The multisig message proposal.
-   * @throws {Error} If the account is not an owner of the multisig wallet.
-   * @throws {NoSuchElementError} If no message exists for the given id.
-   */
-  async approveMessageProposal (messageId) {
-    throw new NotImplementedError('approveMessageProposal(messageId)')
   }
 
   /**

--- a/src/multisig/wallet-account-read-only-multisig.js
+++ b/src/multisig/wallet-account-read-only-multisig.js
@@ -37,15 +37,6 @@ import { NotImplementedError } from '../errors.js'
  * @property {'pending' | 'executed'} status - The proposal's lifecycle state: `'pending'` while it still awaits confirmations or on-chain execution, `'executed'` once it has been executed on-chain.
  */
 
-/**
- * @typedef {Object} MultisigMessageProposal
- * @property {string} messageId - The message's hash.
- * @property {string} message - The original message.
- * @property {number} confirmations - The current number of confirmations.
- * @property {number} threshold -  The minimum amount of confirmations to sign the message.
- * @property {string | null} combinedSignature - The final combined signature when the threshold is met.
- */
-
 /** @interface */
 export class IWalletAccountReadOnlyMultisig extends IWalletAccountReadOnlySimple {
   /**
@@ -76,27 +67,6 @@ export class IWalletAccountReadOnlyMultisig extends IWalletAccountReadOnlySimple
    */
   async getProposal (proposalId) {
     throw new NotImplementedError('getProposal(proposalId)')
-  }
-
-  /**
-   * Returns a list of message proposals by their hashes.
-   *
-   * @param {string[]} messageIds - The list of message hashes
-   * @returns {Promise<Record<string, MultisigMessageProposal | null>>} For each message hash, the message details or
-   *   null if the message has not been found.
-   */
-  async getMessageProposals (messageIds) {
-    throw new NotImplementedError('getMessageProposals(messageIds)')
-  }
-
-  /**
-   * Returns a message proposal by its identifier.
-   *
-   * @param {string} messageId - The message's hash.
-   * @returns {Promise<MultisigMessageProposal | null>} The message details, or null if it has not been found.
-   */
-  async getMessageProposal (messageId) {
-    throw new NotImplementedError('getMessageProposal(messageId)')
   }
 
   /**

--- a/types/src/multisig/index.d.ts
+++ b/types/src/multisig/index.d.ts
@@ -1,10 +1,11 @@
 export { IWalletAccountReadOnlyMultisig } from "./wallet-account-read-only-multisig.js";
 export { IWalletAccountMultisig } from "./wallet-account-multisig.js";
 export { IMultisigOwnerManagement } from "./multisig-owner-management.js";
-export { IMultisigReadOnlyMessageSigning, IMultisigMessageSigning } from "./multisig-message-signing.js";
+export { IMultisigMessageSigningReadOnly } from "./multisig-message-signing-read-only.js";
+export { IMultisigMessageSigning } from "./multisig-message-signing.js";
 export type MultisigInfo = import("./wallet-account-read-only-multisig.js").MultisigInfo;
 export type MultisigProposal = import("./wallet-account-read-only-multisig.js").MultisigProposal;
-export type MultisigMessageProposal = import("./multisig-message-signing.js").MultisigMessageProposal;
+export type MultisigMessageProposal = import("./multisig-message-signing-read-only.js").MultisigMessageProposal;
 export type KeyPair = import("../wallet-account.js").KeyPair;
 export type MultisigTransactionOptions = import("./wallet-account-multisig.js").MultisigTransactionOptions;
 export type MultisigAutoExecuteResult = import("./wallet-account-multisig.js").MultisigAutoExecuteResult;

--- a/types/src/multisig/index.d.ts
+++ b/types/src/multisig/index.d.ts
@@ -1,11 +1,12 @@
 export { IWalletAccountReadOnlyMultisig } from "./wallet-account-read-only-multisig.js";
 export { IWalletAccountMultisig } from "./wallet-account-multisig.js";
 export { IMultisigOwnerManagement } from "./multisig-owner-management.js";
+export { IMultisigReadOnlyMessageSigning, IMultisigMessageSigning } from "./multisig-message-signing.js";
 export type MultisigInfo = import("./wallet-account-read-only-multisig.js").MultisigInfo;
 export type MultisigProposal = import("./wallet-account-read-only-multisig.js").MultisigProposal;
-export type MultisigMessageProposal = import("./wallet-account-read-only-multisig.js").MultisigMessageProposal;
+export type MultisigMessageProposal = import("./multisig-message-signing.js").MultisigMessageProposal;
 export type KeyPair = import("../wallet-account.js").KeyPair;
 export type MultisigTransactionOptions = import("./wallet-account-multisig.js").MultisigTransactionOptions;
 export type MultisigAutoExecuteResult = import("./wallet-account-multisig.js").MultisigAutoExecuteResult;
-export type MultisigSignature = import("./wallet-account-multisig.js").MultisigSignature;
+export type MultisigSignature = import("./multisig-message-signing.js").MultisigSignature;
 export type MultisigOptions = import("./multisig-owner-management.js").MultisigOptions;

--- a/types/src/multisig/multisig-message-signing-read-only.d.ts
+++ b/types/src/multisig/multisig-message-signing-read-only.d.ts
@@ -1,0 +1,44 @@
+/**
+ * Adds the read-only message-signing queries to a multisig wallet.
+ *
+ * @interface
+ */
+export interface IMultisigMessageSigningReadOnly {
+    /**
+     * Returns a list of message proposals by their hashes.
+     *
+     * @param {string[]} messageIds - The list of message hashes
+     * @returns {Promise<Record<string, MultisigMessageProposal | null>>} For each message hash, the message details or
+     *   null if the message has not been found.
+     */
+    getMessageProposals(messageIds: string[]): Promise<Record<string, MultisigMessageProposal | null>>;
+    /**
+     * Returns a message proposal by its identifier.
+     *
+     * @param {string} messageId - The message's hash.
+     * @returns {Promise<MultisigMessageProposal | null>} The message details, or null if it has not been found.
+     */
+    getMessageProposal(messageId: string): Promise<MultisigMessageProposal | null>;
+}
+export type MultisigMessageProposal = {
+    /**
+     * - The message's hash.
+     */
+    messageId: string;
+    /**
+     * - The original message.
+     */
+    message: string;
+    /**
+     * - The current number of confirmations.
+     */
+    confirmations: number;
+    /**
+     * - The minimum amount of confirmations to sign the message.
+     */
+    threshold: number;
+    /**
+     * - The final combined signature when the threshold is met.
+     */
+    combinedSignature: string | null;
+};

--- a/types/src/multisig/multisig-message-signing.d.ts
+++ b/types/src/multisig/multisig-message-signing.d.ts
@@ -1,0 +1,75 @@
+/**
+ * Adds the read-only message-signing queries to a multisig wallet.
+ *
+ * @interface
+ */
+export interface IMultisigReadOnlyMessageSigning {
+    /**
+     * Returns a list of message proposals by their hashes.
+     *
+     * @param {string[]} messageIds - The list of message hashes
+     * @returns {Promise<Record<string, MultisigMessageProposal | null>>} For each message hash, the message details or
+     *   null if the message has not been found.
+     */
+    getMessageProposals(messageIds: string[]): Promise<Record<string, MultisigMessageProposal | null>>;
+    /**
+     * Returns a message proposal by its identifier.
+     *
+     * @param {string} messageId - The message's hash.
+     * @returns {Promise<MultisigMessageProposal | null>} The message details, or null if it has not been found.
+     */
+    getMessageProposal(messageId: string): Promise<MultisigMessageProposal | null>;
+}
+/**
+ * Adds message-signing features to a multisig wallet.
+ *
+ * @interface
+ */
+export interface IMultisigMessageSigning extends IMultisigReadOnlyMessageSigning {
+    /**
+     * Proposes signing a message.
+     *
+     * @param {string} message - The message to sign.
+     * @returns {Promise<MultisigMessageProposal & MultisigSignature>} The multisig message proposal.
+     * @throws {Error} If the account is not an owner of the multisig wallet.
+     */
+    proposeMessage(message: string): Promise<MultisigMessageProposal & MultisigSignature>;
+    /**
+     * Approves an existing message proposal.
+     *
+     * @param {string} messageId - The message's hash.
+     * @returns {Promise<MultisigMessageProposal & MultisigSignature>} The multisig message proposal.
+     * @throws {Error} If the account is not an owner of the multisig wallet.
+     * @throws {NoSuchElementError} If no message exists for the given id.
+     */
+    approveMessageProposal(messageId: string): Promise<MultisigMessageProposal & MultisigSignature>;
+}
+export type MultisigMessageProposal = {
+    /**
+     * - The message's hash.
+     */
+    messageId: string;
+    /**
+     * - The original message.
+     */
+    message: string;
+    /**
+     * - The current number of confirmations.
+     */
+    confirmations: number;
+    /**
+     * - The minimum amount of confirmations to sign the message.
+     */
+    threshold: number;
+    /**
+     * - The final combined signature when the threshold is met.
+     */
+    combinedSignature: string | null;
+};
+export type MultisigSignature = {
+    /**
+     * - The caller's signature.
+     */
+    signature: string;
+};
+export type NoSuchElementError = import("../errors.js").NoSuchElementError;

--- a/types/src/multisig/multisig-message-signing.d.ts
+++ b/types/src/multisig/multisig-message-signing.d.ts
@@ -1,31 +1,9 @@
 /**
- * Adds the read-only message-signing queries to a multisig wallet.
- *
- * @interface
- */
-export interface IMultisigReadOnlyMessageSigning {
-    /**
-     * Returns a list of message proposals by their hashes.
-     *
-     * @param {string[]} messageIds - The list of message hashes
-     * @returns {Promise<Record<string, MultisigMessageProposal | null>>} For each message hash, the message details or
-     *   null if the message has not been found.
-     */
-    getMessageProposals(messageIds: string[]): Promise<Record<string, MultisigMessageProposal | null>>;
-    /**
-     * Returns a message proposal by its identifier.
-     *
-     * @param {string} messageId - The message's hash.
-     * @returns {Promise<MultisigMessageProposal | null>} The message details, or null if it has not been found.
-     */
-    getMessageProposal(messageId: string): Promise<MultisigMessageProposal | null>;
-}
-/**
  * Adds message-signing features to a multisig wallet.
  *
  * @interface
  */
-export interface IMultisigMessageSigning extends IMultisigReadOnlyMessageSigning {
+export interface IMultisigMessageSigning extends IMultisigMessageSigningReadOnly {
     /**
      * Proposes signing a message.
      *
@@ -44,32 +22,12 @@ export interface IMultisigMessageSigning extends IMultisigReadOnlyMessageSigning
      */
     approveMessageProposal(messageId: string): Promise<MultisigMessageProposal & MultisigSignature>;
 }
-export type MultisigMessageProposal = {
-    /**
-     * - The message's hash.
-     */
-    messageId: string;
-    /**
-     * - The original message.
-     */
-    message: string;
-    /**
-     * - The current number of confirmations.
-     */
-    confirmations: number;
-    /**
-     * - The minimum amount of confirmations to sign the message.
-     */
-    threshold: number;
-    /**
-     * - The final combined signature when the threshold is met.
-     */
-    combinedSignature: string | null;
-};
+export type NoSuchElementError = import("../errors.js").NoSuchElementError;
+export type MultisigMessageProposal = import("./multisig-message-signing-read-only.js").MultisigMessageProposal;
 export type MultisigSignature = {
     /**
      * - The caller's signature.
      */
     signature: string;
 };
-export type NoSuchElementError = import("../errors.js").NoSuchElementError;
+import { IMultisigMessageSigningReadOnly } from './multisig-message-signing-read-only.js';

--- a/types/src/multisig/wallet-account-multisig.d.ts
+++ b/types/src/multisig/wallet-account-multisig.d.ts
@@ -36,23 +36,6 @@ export interface IWalletAccountMultisig extends IWalletAccountReadOnlyMultisig {
      */
     propose(tx: Transaction, transactionOptions?: MultisigTransactionOptions): Promise<MultisigProposal & MultisigAutoExecuteResult>;
     /**
-     * Proposes signing a message.
-     *
-     * @param {string} message - The message to sign.
-     * @returns {Promise<MultisigMessageProposal & MultisigSignature>} The multisig message proposal.
-     * @throws {Error} If the account is not an owner of the multisig wallet.
-     */
-    proposeMessage(message: string): Promise<MultisigMessageProposal & MultisigSignature>;
-    /**
-     * Approves an existing message proposal.
-     *
-     * @param {string} messageId - The message's hash.
-     * @returns {Promise<MultisigMessageProposal & MultisigSignature>} The multisig message proposal.
-     * @throws {Error} If the account is not an owner of the multisig wallet.
-     * @throws {NoSuchElementError} If no message exists for the given id.
-     */
-    approveMessageProposal(messageId: string): Promise<MultisigMessageProposal & MultisigSignature>;
-    /**
      * Approves a pending proposal.
      *
      * @param {string} proposalId - The proposal's id.
@@ -83,7 +66,6 @@ export type Transaction = import("../wallet-account-read-only.js").Transaction;
 export type TransactionResult = import("../wallet-account-read-only.js").TransactionResult;
 export type KeyPair = import("../wallet-account.js").KeyPair;
 export type MultisigProposal = import("./wallet-account-read-only-multisig.js").MultisigProposal;
-export type MultisigMessageProposal = import("./wallet-account-read-only-multisig.js").MultisigMessageProposal;
 export type NoSuchElementError = import("../errors.js").NoSuchElementError;
 export type ValueError = import("../errors.js").ValueError;
 export type MultisigTransactionOptions = {
@@ -97,11 +79,5 @@ export type MultisigAutoExecuteResult = {
      * - If auto execute is set to true and the method call triggers the execution of the proposal, this field is set to the corresponding transaction's result (i.e., hash and fee).
      */
     transaction?: TransactionResult;
-};
-export type MultisigSignature = {
-    /**
-     * - The caller's signature.
-     */
-    signature: string;
 };
 import { IWalletAccountReadOnlyMultisig } from './wallet-account-read-only-multisig.js';

--- a/types/src/multisig/wallet-account-read-only-multisig.d.ts
+++ b/types/src/multisig/wallet-account-read-only-multisig.d.ts
@@ -22,21 +22,6 @@ export interface IWalletAccountReadOnlyMultisig extends IWalletAccountReadOnlySi
      */
     getProposal(proposalId: string): Promise<MultisigProposal | null>;
     /**
-     * Returns a list of message proposals by their hashes.
-     *
-     * @param {string[]} messageIds - The list of message hashes
-     * @returns {Promise<Record<string, MultisigMessageProposal | null>>} For each message hash, the message details or
-     *   null if the message has not been found.
-     */
-    getMessageProposals(messageIds: string[]): Promise<Record<string, MultisigMessageProposal | null>>;
-    /**
-     * Returns a message proposal by its identifier.
-     *
-     * @param {string} messageId - The message's hash.
-     * @returns {Promise<MultisigMessageProposal | null>} The message details, or null if it has not been found.
-     */
-    getMessageProposal(messageId: string): Promise<MultisigMessageProposal | null>;
-    /**
      * Quotes the on-chain cost of executing a pending proposal.
      *
      * @param {string} proposalId - The proposal's id.
@@ -76,28 +61,6 @@ export type MultisigProposal = {
      * - The proposal's lifecycle state: `'pending'` while it still awaits confirmations or on-chain execution, `'executed'` once it has been executed on-chain.
      */
     status: 'pending' | 'executed';
-};
-export type MultisigMessageProposal = {
-    /**
-     * - The message's hash.
-     */
-    messageId: string;
-    /**
-     * - The original message.
-     */
-    message: string;
-    /**
-     * - The current number of confirmations.
-     */
-    confirmations: number;
-    /**
-     * -  The minimum amount of confirmations to sign the message.
-     */
-    threshold: number;
-    /**
-     * - The final combined signature when the threshold is met.
-     */
-    combinedSignature: string | null;
 };
 export type TransactionResult = import("../wallet-account-read-only.js").TransactionResult;
 import { IWalletAccountReadOnlySimple } from '../wallet-account-read-only-simple.js';


### PR DESCRIPTION
## Summary

Make **multisig message-signing an optional capability**, instead of requiring it of every implementer. Message-signing (`proposeMessage` / `approveMessageProposal` / `getMessageProposal` / `getMessageProposals`) moves out of the core `IWalletAccountReadOnlyMultisig` / `IWalletAccountMultisig` into two optional interfaces, mirroring `IMultisigOwnerManagement`.

## Motivation

The third multisig implementation — **Solana Squads** (`wdk-protocol-multisig-squads`) — surfaced that message-signing isn't universal. A multisig account is a **keyless** program-controlled address (a PDA on Solana, a contract on EVM), so it can't sign as itself. EVM Safe works around this with **EIP-1271** (a standard letting a keyless contract validate a "the multisig approved this message" signature). **Solana has no EIP-1271 equivalent** and Squads has no message-approval primitive — so the Squads module can only stub-throw `NotSupported` on every message method. Forcing methods onto an implementer that can never fulfil them is the wrong contract; message-signing should be opt-in.

## Changes

- New `src/multisig/multisig-message-signing.js`:
  - `IMultisigReadOnlyMessageSigning` — `getMessageProposal`, `getMessageProposals` (optional, read-only).
  - `IMultisigMessageSigning extends IMultisigReadOnlyMessageSigning` — adds `proposeMessage`, `approveMessageProposal` (optional, writable).
  - Owns the `MultisigMessageProposal` and `MultisigSignature` typedefs.
- Removed those four methods + two typedefs from the core `IWalletAccountReadOnlyMultisig` / `IWalletAccountMultisig`.
- Updated the `/multisig` barrel and the hand-maintained `.d.ts`.

## Impact on implementers

- **EVM Safe:** read-only class `@implements IMultisigReadOnlyMessageSigning`, writable class `@implements IMultisigMessageSigning` — behaviour unchanged.
- **Solana Squads:** implements neither → the message methods (and their `NotSupported` throws) simply go away.
- Breaking to the interface surface, but pre-GA beta; no released implementation depends on these being on the *core* interfaces.

## Out of scope: `verify`

Squads also can't implement `verify(message, signature)` (same reason — no EIP-1271, no signature attributable to a keyless multisig). But `verify` lives on the **base `IWalletAccountReadOnlySimple`**, shared by *every* wallet account — not just multisigs. Making it optional touches the whole wallet-account hierarchy, a much larger blast radius. To keep this PR atomic to multisig message-signing, `verify` is left as-is and tracked separately; Squads keeps throwing on `verify` until that's addressed.

## Testing

`npm run lint` clean, `npm test` 19/19. Interfaces are abstract (`NotImplementedError` stubs), so there are no direct interface tests; the change is verified structurally (exports + inheritance).
