### PR TITLE
Release: v1.0.0-beta.17

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tetherto/wdk-wallet",
-  "version": "1.0.0-beta.16",
+  "version": "1.0.0-beta.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tetherto/wdk-wallet",
-      "version": "1.0.0-beta.16",
+      "version": "1.0.0-beta.17",
       "license": "Apache-2.0",
       "dependencies": {
         "bare-node-runtime": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tetherto/wdk-wallet",
-  "version": "1.0.0-beta.16",
+  "version": "1.0.0-beta.17",
   "description": "A simple package to manage BIP-32 wallets.",
   "keywords": [
     "wdk",


### PR DESCRIPTION
- Bump version to 1.0.0-beta.17

### Changes since v1.0.0-beta.16
- Add `waitForTransaction` and `getTransaction` with cross-chain receipt types (#56)
- refactor(multisig): make message-signing an optional capability interface (#63)
- Improve errors across protocol types and new multisig methods (#54)

### Dependency updates
- None (version-only release)