### PR TITLE
fix(multisig): restore auto-execute transaction result to propose/approveProposal

### DIFF
--- a/src/multisig/wallet-account-multisig.js
+++ b/src/multisig/wallet-account-multisig.js
@@ -88,7 +88,7 @@ export class IWalletAccountMultisig extends IWalletAccountReadOnlyMultisig {
    *
    * @param {Transaction} tx - The transaction.
    * @param {MultisigTransactionOptions} [transactionOptions] - The multisig transaction's options.
-   * @returns {Promise<MultisigProposal>} The created proposal; its `status` is `'executed'` when `autoExecute` ran to completion, otherwise `'pending'`.
+   * @returns {Promise<MultisigProposal & MultisigAutoExecuteResult>} The created proposal; its `status` is `'executed'` when `autoExecute` ran to completion, otherwise `'pending'`.
    * @throws {ValueError} If the transaction is not valid.
    * @throws {ProviderRequiredError} If the method requires a provider.
    * @throws {ProviderError} If the provider fails to propose the transaction.
@@ -102,7 +102,7 @@ export class IWalletAccountMultisig extends IWalletAccountReadOnlyMultisig {
    * Approves a pending proposal.
    *
    * @param {string} proposalId - The proposal's id.
-   * @returns {Promise<MultisigProposal>} The multisig proposal.
+   * @returns {Promise<MultisigProposal & MultisigAutoExecuteResult>} The multisig proposal.
    * @throws {ValueError} If the proposal's identifier is not a valid id.
    * @throws {NoSuchElementError} If no message exists for the given id.
    * @throws {AccountNotOwnerError} If the account is not an owner of the multisig wallet.

--- a/types/src/multisig/wallet-account-multisig.d.ts
+++ b/types/src/multisig/wallet-account-multisig.d.ts
@@ -37,7 +37,7 @@ export interface IWalletAccountMultisig extends IWalletAccountReadOnlyMultisig {
      * @throws {ProviderError} If the provider fails to propose the transaction.
      * @throws {AccountNotOwnerError} If the account is not an owner of the multisig wallet.
      */
-    propose(tx: Transaction, transactionOptions?: MultisigTransactionOptions): Promise<MultisigProposal>;
+    propose(tx: Transaction, transactionOptions?: MultisigTransactionOptions): Promise<MultisigProposal & MultisigAutoExecuteResult>;
     /**
      * Approves a pending proposal.
      *
@@ -47,7 +47,7 @@ export interface IWalletAccountMultisig extends IWalletAccountReadOnlyMultisig {
      * @throws {NoSuchElementError} If no message exists for the given id.
      * @throws {AccountNotOwnerError} If the account is not an owner of the multisig wallet.
      */
-    approveProposal(proposalId: string): Promise<MultisigProposal>;
+    approveProposal(proposalId: string): Promise<MultisigProposal & MultisigAutoExecuteResult>;
     /**
      * Rejects a pending proposal.
      *


### PR DESCRIPTION
## Problem

With `autoExecute: true`, `propose` (or the threshold-crossing `approveProposal`) executes the proposal on-chain — but on `v1.0.0-beta.17` the return type carries no `transaction`, so callers have no way to get the resulting hash/fee and track the transaction.

## Root cause

- #60 added `MultisigAutoExecuteResult` (`{ transaction? }`) to the `propose`/`approveProposal` return types (shipped in `v1.0.0-beta.16`).
- #54's sync-merge `d9d9b30` ("Merge branch 'main' into feature/errors") had branched off **before** #60; on merge, its stale copy of `wallet-account-multisig.js` won — silently dropping `& MultisigAutoExecuteResult` from both returns while leaving the type defined and exported (orphaned).
- The regression shipped in **`v1.0.0-beta.17`**.

## Fix

Restore the intersection on `propose` and `approveProposal`. `rejectProposal` stays plain — a reject never triggers execution. Purely additive → **not a breaking change**. The hand-maintained `.d.ts` mirror is updated to match.

## Verification

- `standard` lint clean
- `jest` 27/27 pass
