### PR TITLE
fix: export SignerError as an alias of InvalidSignerError

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,4 +39,4 @@ export { IWalletAccount } from './src/wallet-account.js'
 
 export { ISigner } from './src/signer.js'
 
-export { AssertionError, InvalidTokenError, InvalidSignerError, MaximumFeeExceededError, NoSuchElementError, NotImplementedError, ProviderError, ProviderErrorReason, ProviderRequiredError, TimeoutError, TransactionError, TransactionErrorReason, TransferError, TransferErrorReason, UnsupportedOperationError, ValueError, WdkError } from './src/errors.js'
+export { AssertionError, InvalidTokenError, InvalidSignerError, InvalidSignerError as SignerError, MaximumFeeExceededError, NoSuchElementError, NotImplementedError, ProviderError, ProviderErrorReason, ProviderRequiredError, TimeoutError, TransactionError, TransactionErrorReason, TransferError, TransferErrorReason, UnsupportedOperationError, ValueError, WdkError } from './src/errors.js'

--- a/tests/errors.test.js
+++ b/tests/errors.test.js
@@ -1,0 +1,9 @@
+import { describe, expect, test } from '@jest/globals'
+
+import { InvalidSignerError, SignerError } from '../index.js'
+
+describe('errors', () => {
+  test('SignerError is an alias of InvalidSignerError', () => {
+    expect(SignerError).toBe(InvalidSignerError)
+  })
+})

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -16,4 +16,4 @@ export type ProviderErrorOptions = import("./src/errors.js").ProviderErrorOption
 export type TransactionErrorOptions = import("./src/errors.js").TransactionErrorOptions;
 export type TransferErrorOptions = import("./src/errors.js").TransferErrorOptions;
 export { default as WalletAccountReadOnly, IWalletAccountReadOnly, FINALITY } from "./src/wallet-account-read-only.js";
-export { AssertionError, InvalidTokenError, InvalidSignerError, MaximumFeeExceededError, NoSuchElementError, NotImplementedError, ProviderError, ProviderErrorReason, ProviderRequiredError, TimeoutError, TransactionError, TransactionErrorReason, TransferError, TransferErrorReason, UnsupportedOperationError, ValueError, WdkError } from "./src/errors.js";
+export { AssertionError, InvalidTokenError, InvalidSignerError, InvalidSignerError as SignerError, MaximumFeeExceededError, NoSuchElementError, NotImplementedError, ProviderError, ProviderErrorReason, ProviderRequiredError, TimeoutError, TransactionError, TransactionErrorReason, TransferError, TransferErrorReason, UnsupportedOperationError, ValueError, WdkError } from "./src/errors.js";


### PR DESCRIPTION
- Re-export `SignerError` as an alias of `InvalidSignerError`
- Consumers using `@tetherto/wdk-wallet-evm@1.0.0-beta.15` & older import `SignerError`. Without it here, ESM eval throws.