### PR TITLE
Release: v1.0.0-beta.18

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tetherto/wdk-wallet",
-  "version": "1.0.0-beta.17",
+  "version": "1.0.0-beta.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tetherto/wdk-wallet",
-      "version": "1.0.0-beta.17",
+      "version": "1.0.0-beta.18",
       "license": "Apache-2.0",
       "dependencies": {
         "bare-node-runtime": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tetherto/wdk-wallet",
-  "version": "1.0.0-beta.17",
+  "version": "1.0.0-beta.18",
   "description": "A simple package to manage BIP-32 wallets.",
   "keywords": [
     "wdk",


### PR DESCRIPTION
- Bump version to 1.0.0-beta.18

### Changes since v1.0.0-beta.17
- fix(multisig): restore auto-execute transaction result to propose/approveProposal (#65)
- fix: export SignerError as an alias of InvalidSignerError (#67)

### Dependency updates
- None (version-only release)